### PR TITLE
TypeAnnotation and AnnotationValue API improvements

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/AnnotationValue.java
+++ b/src/java.base/share/classes/jdk/classfile/AnnotationValue.java
@@ -66,11 +66,78 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
 
     /** Models a constant-valued element */
     sealed interface OfConstant extends AnnotationValue
-            permits AnnotationImpl.OfConstantImpl {
+            permits AnnotationValue.OfString, AnnotationValue.OfDouble,
+                    AnnotationValue.OfFloat, AnnotationValue.OfLong,
+                    AnnotationValue.OfInteger, AnnotationValue.OfShort,
+                    AnnotationValue.OfCharacter, AnnotationValue.OfByte,
+                    AnnotationValue.OfBoolean, AnnotationImpl.OfConstantImpl {
         /** {@return the constant} */
         AnnotationConstantValueEntry constant();
         /** {@return the constant} */
         ConstantDesc constantValue();
+    }
+
+    /** Models a constant-valued element */
+    sealed interface OfString extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfStringImpl {
+        /** {@return the constant} */
+        String stringValue();
+    }
+
+    /** Models a constant-valued element */
+    sealed interface OfDouble extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfDoubleImpl {
+        /** {@return the constant} */
+        double doubleValue();
+    }
+
+    /** Models a constant-valued element */
+    sealed interface OfFloat extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfFloatImpl {
+        /** {@return the constant} */
+        float floatValue();
+    }
+
+    /** Models a constant-valued element */
+    sealed interface OfLong extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfLongImpl {
+        /** {@return the constant} */
+        long longValue();
+    }
+
+    /** Models a constant-valued element */
+    sealed interface OfInteger extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfIntegerImpl {
+        /** {@return the constant} */
+        int intValue();
+    }
+
+    /** Models a constant-valued element */
+    sealed interface OfShort extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfShortImpl {
+        /** {@return the constant} */
+        short shortValue();
+    }
+
+    /** Models a constant-valued element */
+    sealed interface OfCharacter extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfCharacterImpl {
+        /** {@return the constant} */
+        char charValue();
+    }
+
+    /** Models a constant-valued element */
+    sealed interface OfByte extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfByteImpl {
+        /** {@return the constant} */
+        byte byteValue();
+    }
+
+    /** Models a constant-valued element */
+    sealed interface OfBoolean extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfBooleanImpl {
+        /** {@return the constant} */
+        boolean booleanValue();
     }
 
     /** Models a class-valued element */
@@ -78,6 +145,11 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
             permits AnnotationImpl.OfClassImpl {
         /** {@return the class name} */
         Utf8Entry className();
+
+        /** {@return the class symbol} */
+        default ClassDesc classSymbol() {
+            return ClassDesc.ofDescriptor(className().stringValue());
+        }
     }
 
     /** Models an enum-valued element */
@@ -85,6 +157,11 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
             permits AnnotationImpl.OfEnumImpl {
         /** {@return the enum class name} */
         Utf8Entry className();
+
+        /** {@return the enum class symbol} */
+        default ClassDesc classSymbol() {
+            return ClassDesc.ofDescriptor(className().stringValue());
+        }
 
         /** {@return the enum constant name} */
         Utf8Entry constantName();
@@ -136,7 +213,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @param value the string
      */
     static OfConstant ofString(Utf8Entry value) {
-        return new AnnotationImpl.OfConstantImpl('s', value);
+        return new AnnotationImpl.OfStringImpl(value);
     }
 
     /**
@@ -152,7 +229,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @param value the double value
      */
     static OfConstant ofDouble(DoubleEntry value) {
-        return new AnnotationImpl.OfConstantImpl('D', value);
+        return new AnnotationImpl.OfDoubleImpl(value);
     }
 
     /**
@@ -168,7 +245,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @param value the float value
      */
     static OfConstant ofFloat(FloatEntry value) {
-        return new AnnotationImpl.OfConstantImpl('F', value);
+        return new AnnotationImpl.OfFloatImpl(value);
     }
 
     /**
@@ -184,7 +261,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @param value the long value
      */
     static OfConstant ofLong(LongEntry value) {
-        return new AnnotationImpl.OfConstantImpl('J', value);
+        return new AnnotationImpl.OfLongImpl(value);
     }
 
     /**
@@ -200,7 +277,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @param value the int value
      */
     static OfConstant ofInt(IntegerEntry value) {
-        return new AnnotationImpl.OfConstantImpl('I', value);
+        return new AnnotationImpl.OfIntegerImpl(value);
     }
 
     /**
@@ -216,7 +293,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @param value the short value
      */
     static OfConstant ofShort(IntegerEntry value) {
-        return new AnnotationImpl.OfConstantImpl('S', value);
+        return new AnnotationImpl.OfShortImpl(value);
     }
 
     /**
@@ -232,7 +309,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @param value the char value
      */
     static OfConstant ofChar(IntegerEntry value) {
-        return new AnnotationImpl.OfConstantImpl('C', value);
+        return new AnnotationImpl.OfCharacterImpl(value);
     }
 
     /**
@@ -248,7 +325,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @param value the byte value
      */
     static OfConstant ofByte(IntegerEntry value) {
-        return new AnnotationImpl.OfConstantImpl('B', value);
+        return new AnnotationImpl.OfByteImpl(value);
     }
 
     /**
@@ -264,7 +341,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @param value the boolean value
      */
     static OfConstant ofBoolean(IntegerEntry value) {
-        return new AnnotationImpl.OfConstantImpl('Z', value);
+        return new AnnotationImpl.OfBooleanImpl(value);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/classfile/TypeAnnotation.java
+++ b/src/java.base/share/classes/jdk/classfile/TypeAnnotation.java
@@ -25,6 +25,7 @@
 
 package jdk.classfile;
 
+import java.lang.constant.ClassDesc;
 import java.util.List;
 import java.util.Set;
 
@@ -56,6 +57,7 @@ import static jdk.classfile.Classfile.TAT_METHOD_TYPE_PARAMETER_BOUND;
 import static jdk.classfile.Classfile.TAT_NEW;
 import static jdk.classfile.Classfile.TAT_RESOURCE_VARIABLE;
 import static jdk.classfile.Classfile.TAT_THROWS;
+import jdk.classfile.impl.TemporaryConstantPool;
 
 /**
  * Models an annotation on a type use.
@@ -176,13 +178,53 @@ public sealed interface TypeAnnotation
      * @param targetInfo which type in a declaration or expression is annotated
      * @param targetPath which part of the type is annotated
      * @param annotationClassUtf8Entry the annotation class
-     * @param annotationElements the annltation elements
+     * @param annotationElements the annotation elements
      */
     static TypeAnnotation of(TargetInfo targetInfo, List<TypePathComponent> targetPath,
                              Utf8Entry annotationClassUtf8Entry,
                              List<AnnotationElement> annotationElements) {
         return new UnboundAttribute.UnboundTypeAnnotation(targetInfo, targetPath,
                 annotationClassUtf8Entry, annotationElements);
+    }
+
+    /**
+     * {@return a type annotation}
+     * @param targetInfo which type in a declaration or expression is annotated
+     * @param targetPath which part of the type is annotated
+     * @param annotationClass the annotation class
+     * @param annotationElements the annotation elements
+     */
+    static TypeAnnotation of(TargetInfo targetInfo, List<TypePathComponent> targetPath,
+                             ClassDesc annotationClass,
+                             AnnotationElement... annotationElements) {
+        return of(targetInfo, targetPath, annotationClass, List.of(annotationElements));
+    }
+
+    /**
+     * {@return a type annotation}
+     * @param targetInfo which type in a declaration or expression is annotated
+     * @param targetPath which part of the type is annotated
+     * @param annotationClass the annotation class
+     * @param annotationElements the annotation elements
+     */
+    static TypeAnnotation of(TargetInfo targetInfo, List<TypePathComponent> targetPath,
+                             ClassDesc annotationClass,
+                             List<AnnotationElement> annotationElements) {
+        return of(targetInfo, targetPath,
+                TemporaryConstantPool.INSTANCE.utf8Entry(annotationClass.descriptorString()), annotationElements);
+    }
+
+    /**
+     * {@return a type annotation}
+     * @param targetInfo which type in a declaration or expression is annotated
+     * @param targetPath which part of the type is annotated
+     * @param annotationClassUtf8Entry the annotation class
+     * @param annotationElements the annotation elements
+     */
+    static TypeAnnotation of(TargetInfo targetInfo, List<TypePathComponent> targetPath,
+                             Utf8Entry annotationClassUtf8Entry,
+                             AnnotationElement... annotationElements) {
+        return of(targetInfo, targetPath, annotationClassUtf8Entry, List.of(annotationElements));
     }
 
     /**

--- a/src/java.base/share/classes/jdk/classfile/TypeAnnotation.java
+++ b/src/java.base/share/classes/jdk/classfile/TypeAnnotation.java
@@ -238,36 +238,48 @@ public sealed interface TypeAnnotation
             return targetType().sizeIfFixed;
         }
 
+        static TypeParameterTarget ofTypeParameter(TargetType targetType, int typeParameterIndex) {
+            return new TargetInfoImpl.TypeParameterTargetImpl(targetType, typeParameterIndex);
+        }
+
         static TypeParameterTarget ofClassTypeParameter(int typeParameterIndex) {
-            return new TargetInfoImpl.TypeParameterTargetImpl(TargetType.CLASS_TYPE_PARAMETER, typeParameterIndex);
+            return ofTypeParameter(TargetType.CLASS_TYPE_PARAMETER, typeParameterIndex);
         }
 
         static TypeParameterTarget ofMethodTypeParameter(int typeParameterIndex) {
-            return new TargetInfoImpl.TypeParameterTargetImpl(TargetType.METHOD_TYPE_PARAMETER, typeParameterIndex);
+            return ofTypeParameter(TargetType.METHOD_TYPE_PARAMETER, typeParameterIndex);
         }
 
         static SupertypeTarget ofClassExtends(int supertypeIndex) {
             return new TargetInfoImpl.SupertypeTargetImpl(supertypeIndex);
         }
 
+        static TypeParameterBoundTarget ofTypeParameterBound(TargetType targetType, int typeParameterIndex, int boundIndex) {
+            return new TargetInfoImpl.TypeParameterBoundTargetImpl(targetType, typeParameterIndex, boundIndex);
+        }
+
         static TypeParameterBoundTarget ofClassTypeParameterBound(int typeParameterIndex, int boundIndex) {
-            return new TargetInfoImpl.TypeParameterBoundTargetImpl(TargetType.CLASS_TYPE_PARAMETER_BOUND, typeParameterIndex, boundIndex);
+            return ofTypeParameterBound(TargetType.CLASS_TYPE_PARAMETER_BOUND, typeParameterIndex, boundIndex);
         }
 
         static TypeParameterBoundTarget ofMethodTypeParameterBound(int typeParameterIndex, int boundIndex) {
-            return new TargetInfoImpl.TypeParameterBoundTargetImpl(TargetType.METHOD_TYPE_PARAMETER_BOUND, typeParameterIndex, boundIndex);
+            return ofTypeParameterBound(TargetType.METHOD_TYPE_PARAMETER_BOUND, typeParameterIndex, boundIndex);
+        }
+
+        static EmptyTarget of(TargetType targetType) {
+            return new TargetInfoImpl.EmptyTargetImpl(targetType);
         }
 
         static EmptyTarget ofField() {
-            return new TargetInfoImpl.EmptyTargetImpl(TargetType.FIELD);
+            return of(TargetType.FIELD);
         }
 
         static EmptyTarget ofMethodReturn() {
-            return new TargetInfoImpl.EmptyTargetImpl(TargetType.METHOD_RETURN);
+            return of(TargetType.METHOD_RETURN);
         }
 
         static EmptyTarget ofMethodReceiver() {
-            return new TargetInfoImpl.EmptyTargetImpl(TargetType.METHOD_RECEIVER);
+            return of(TargetType.METHOD_RECEIVER);
         }
 
         static FormalParameterTarget ofMethodFormalParameter(int formalParameterIndex) {
@@ -278,52 +290,64 @@ public sealed interface TypeAnnotation
             return new TargetInfoImpl.ThrowsTargetImpl(throwsTargetIndex);
         }
 
+        static LocalVarTarget ofVariable(TargetType targetType, List<LocalVarTargetInfo> table) {
+            return new TargetInfoImpl.LocalVarTargetImpl(targetType, table);
+        }
+
         static LocalVarTarget ofLocalVariable(List<LocalVarTargetInfo> table) {
-            return new TargetInfoImpl.LocalVarTargetImpl(TargetType.LOCAL_VARIABLE, table);
+            return ofVariable(TargetType.LOCAL_VARIABLE, table);
         }
 
         static LocalVarTarget ofResourceVariable(List<LocalVarTargetInfo> table) {
-            return new TargetInfoImpl.LocalVarTargetImpl(TargetType.RESOURCE_VARIABLE, table);
+            return ofVariable(TargetType.RESOURCE_VARIABLE, table);
         }
 
         static CatchTarget ofExceptionParameter(int exceptionTableIndex) {
             return new TargetInfoImpl.CatchTargetImpl(exceptionTableIndex);
         }
 
+        static OffsetTarget ofOffset(TargetType targetType, Label target) {
+            return new TargetInfoImpl.OffsetTargetImpl(targetType, target);
+        }
+
         static OffsetTarget ofInstanceofExpr(Label target) {
-            return new TargetInfoImpl.OffsetTargetImpl(TargetType.INSTANCEOF, target);
+            return ofOffset(TargetType.INSTANCEOF, target);
         }
 
         static OffsetTarget ofNewExpr(Label target) {
-            return new TargetInfoImpl.OffsetTargetImpl(TargetType.NEW, target);
+            return ofOffset(TargetType.NEW, target);
         }
 
         static OffsetTarget ofConstructorReference(Label target) {
-            return new TargetInfoImpl.OffsetTargetImpl(TargetType.CONSTRUCTOR_REFERENCE, target);
+            return ofOffset(TargetType.CONSTRUCTOR_REFERENCE, target);
         }
 
         static OffsetTarget ofMethodReference(Label target) {
-            return new TargetInfoImpl.OffsetTargetImpl(TargetType.METHOD_REFERENCE, target);
+            return ofOffset(TargetType.METHOD_REFERENCE, target);
+        }
+
+        static TypeArgumentTarget ofTypeArgument(TargetType targetType, Label target, int typeArgumentIndex) {
+            return new TargetInfoImpl.TypeArgumentTargetImpl(targetType, target, typeArgumentIndex);
         }
 
         static TypeArgumentTarget ofCastExpr(Label target, int typeArgumentIndex) {
-            return new TargetInfoImpl.TypeArgumentTargetImpl(TargetType.CAST, target, typeArgumentIndex);
+            return ofTypeArgument(TargetType.CAST, target, typeArgumentIndex);
         }
 
         static TypeArgumentTarget ofConstructorInvocationTypeArgument(Label target, int typeArgumentIndex) {
-            return new TargetInfoImpl.TypeArgumentTargetImpl(TargetType.CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT, target, typeArgumentIndex);
+            return ofTypeArgument(TargetType.CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT, target, typeArgumentIndex);
         }
 
         static TypeArgumentTarget ofMethodInvocationTypeArgument(Label target, int typeArgumentIndex) {
-            return new TargetInfoImpl.TypeArgumentTargetImpl(TargetType.METHOD_INVOCATION_TYPE_ARGUMENT, target, typeArgumentIndex);
+            return ofTypeArgument(TargetType.METHOD_INVOCATION_TYPE_ARGUMENT, target, typeArgumentIndex);
         }
 
         static TypeArgumentTarget ofConstructorReferenceTypeArgument(Label target, int typeArgumentIndex) {
-            return new TargetInfoImpl.TypeArgumentTargetImpl(TargetType.CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT, target, typeArgumentIndex);
+            return ofTypeArgument(TargetType.CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT, target, typeArgumentIndex);
         }
 
         static TypeArgumentTarget ofMethodReferenceTypeArgument(Label target, int typeArgumentIndex) {
-            return new TargetInfoImpl.TypeArgumentTargetImpl(TargetType.METHOD_REFERENCE_TYPE_ARGUMENT, target, typeArgumentIndex);
+            return ofTypeArgument(TargetType.METHOD_REFERENCE_TYPE_ARGUMENT, target, typeArgumentIndex);
         }
     }
 

--- a/src/java.base/share/classes/jdk/classfile/impl/AnnotationImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/AnnotationImpl.java
@@ -25,8 +25,7 @@
 package jdk.classfile.impl;
 
 import jdk.classfile.*;
-import jdk.classfile.constantpool.AnnotationConstantValueEntry;
-import jdk.classfile.constantpool.Utf8Entry;
+import jdk.classfile.constantpool.*;
 
 import java.lang.constant.ConstantDesc;
 import java.util.List;
@@ -89,20 +88,150 @@ public final class AnnotationImpl implements Annotation {
         }
     }
 
-    public record OfConstantImpl(char tag, AnnotationConstantValueEntry constant)
-            implements AnnotationValue.OfConstant {
+    public sealed interface OfConstantImpl extends AnnotationValue.OfConstant
+            permits AnnotationImpl.OfStringImpl, AnnotationImpl.OfDoubleImpl,
+                    AnnotationImpl.OfFloatImpl, AnnotationImpl.OfLongImpl,
+                    AnnotationImpl.OfIntegerImpl, AnnotationImpl.OfShortImpl,
+                    AnnotationImpl.OfCharacterImpl, AnnotationImpl.OfByteImpl,
+                    AnnotationImpl.OfBooleanImpl {
 
         @Override
-        public void writeTo(BufWriter buf) {
+        default void writeTo(BufWriter buf) {
             buf.writeU1(tag());
-            buf.writeIndex(constant);
+            buf.writeIndex(constant());
         }
 
         @Override
-        public ConstantDesc constantValue() {
-            return constant.constantValue();
+        default ConstantDesc constantValue() {
+            return constant().constantValue();
         }
 
+    }
+
+    public record OfStringImpl(Utf8Entry constant)
+            implements AnnotationImpl.OfConstantImpl, AnnotationValue.OfString {
+
+        @Override
+        public char tag() {
+            return 's';
+        }
+
+        @Override
+        public String stringValue() {
+            return constant().stringValue();
+        }
+    }
+
+    public record OfDoubleImpl(DoubleEntry constant)
+            implements AnnotationImpl.OfConstantImpl, AnnotationValue.OfDouble {
+
+        @Override
+        public char tag() {
+            return 'D';
+        }
+
+        @Override
+        public double doubleValue() {
+            return constant().doubleValue();
+        }
+    }
+
+    public record OfFloatImpl(FloatEntry constant)
+            implements AnnotationImpl.OfConstantImpl, AnnotationValue.OfFloat {
+
+        @Override
+        public char tag() {
+            return 'F';
+        }
+
+        @Override
+        public float floatValue() {
+            return constant().floatValue();
+        }
+    }
+
+    public record OfLongImpl(LongEntry constant)
+            implements AnnotationImpl.OfConstantImpl, AnnotationValue.OfLong {
+
+        @Override
+        public char tag() {
+            return 'J';
+        }
+
+        @Override
+        public long longValue() {
+            return constant().longValue();
+        }
+    }
+
+    public record OfIntegerImpl(IntegerEntry constant)
+            implements AnnotationImpl.OfConstantImpl, AnnotationValue.OfInteger {
+
+        @Override
+        public char tag() {
+            return 'I';
+        }
+
+        @Override
+        public int intValue() {
+            return constant().intValue();
+        }
+    }
+
+    public record OfShortImpl(IntegerEntry constant)
+            implements AnnotationImpl.OfConstantImpl, AnnotationValue.OfShort {
+
+        @Override
+        public char tag() {
+            return 'S';
+        }
+
+        @Override
+        public short shortValue() {
+            return (short)constant().intValue();
+        }
+    }
+
+    public record OfCharacterImpl(IntegerEntry constant)
+            implements AnnotationImpl.OfConstantImpl, AnnotationValue.OfCharacter {
+
+        @Override
+        public char tag() {
+            return 'C';
+        }
+
+        @Override
+        public char charValue() {
+            return (char)constant().intValue();
+        }
+    }
+
+    public record OfByteImpl(IntegerEntry constant)
+            implements AnnotationImpl.OfConstantImpl, AnnotationValue.OfByte {
+
+        @Override
+        public char tag() {
+            return 'B';
+        }
+
+        @Override
+        public byte byteValue() {
+            return (byte)constant().intValue();
+        }
+    }
+
+    public record OfBooleanImpl(IntegerEntry constant)
+            implements AnnotationImpl.OfConstantImpl, AnnotationValue.OfBoolean {
+
+        @Override
+        public char tag() {
+            return 'Z';
+        }
+
+        @Override
+        public boolean booleanValue() {
+            return constant().intValue() == 1;
+        }
     }
 
     public record OfArrayImpl(List<AnnotationValue> values)

--- a/src/java.base/share/classes/jdk/classfile/impl/AnnotationReader.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/AnnotationReader.java
@@ -29,7 +29,7 @@ import jdk.classfile.Annotation;
 import jdk.classfile.AnnotationElement;
 import jdk.classfile.AnnotationValue;
 import jdk.classfile.ClassReader;
-import jdk.classfile.constantpool.AnnotationConstantValueEntry;
+import jdk.classfile.constantpool.*;
 import jdk.classfile.TypeAnnotation;
 import static jdk.classfile.Classfile.*;
 import static jdk.classfile.TypeAnnotation.TargetInfo.*;
@@ -58,8 +58,15 @@ class AnnotationReader {
         char tag = (char) classReader.readU1(p);
         ++p;
         return switch (tag) {
-            case 'B', 'C', 'D', 'F', 'I', 'J', 'S', 'Z' -> new AnnotationImpl.OfConstantImpl(tag, (AnnotationConstantValueEntry) classReader.readEntry(p));
-            case 's' -> new AnnotationImpl.OfConstantImpl(tag, classReader.readUtf8Entry(p));
+            case 'B' -> new AnnotationImpl.OfByteImpl((IntegerEntry)classReader.readEntry(p));
+            case 'C' -> new AnnotationImpl.OfCharacterImpl((IntegerEntry)classReader.readEntry(p));
+            case 'D' -> new AnnotationImpl.OfDoubleImpl((DoubleEntry)classReader.readEntry(p));
+            case 'F' -> new AnnotationImpl.OfFloatImpl((FloatEntry)classReader.readEntry(p));
+            case 'I' -> new AnnotationImpl.OfIntegerImpl((IntegerEntry)classReader.readEntry(p));
+            case 'J' -> new AnnotationImpl.OfLongImpl((LongEntry)classReader.readEntry(p));
+            case 'S' -> new AnnotationImpl.OfShortImpl((IntegerEntry)classReader.readEntry(p));
+            case 'Z' -> new AnnotationImpl.OfBooleanImpl((IntegerEntry)classReader.readEntry(p));
+            case 's' -> new AnnotationImpl.OfStringImpl(classReader.readUtf8Entry(p));
             case 'e' -> new AnnotationImpl.OfEnumImpl(classReader.readUtf8Entry(p), classReader.readUtf8Entry(p + 2));
             case 'c' -> new AnnotationImpl.OfClassImpl(classReader.readUtf8Entry(p));
             case '@' -> new AnnotationImpl.OfAnnotationImpl(readAnnotation(classReader, p));

--- a/src/java.base/share/classes/jdk/classfile/impl/TargetInfoImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/TargetInfoImpl.java
@@ -25,8 +25,10 @@
 package jdk.classfile.impl;
 
 import java.util.List;
+import java.util.Objects;
 import jdk.classfile.Label;
 import jdk.classfile.TypeAnnotation.*;
+import static jdk.classfile.Classfile.*;
 
 /**
  *
@@ -36,8 +38,20 @@ public final class TargetInfoImpl {
     private TargetInfoImpl() {
     }
 
+    private static TargetType checkValid(TargetType targetType, int rangeFrom, int rangeTo) {
+        Objects.requireNonNull(targetType);
+        if (targetType.targetTypeValue() < rangeFrom || targetType.targetTypeValue() > rangeTo)
+            throw new IllegalArgumentException("Wrong target type specified " + targetType);
+        return targetType;
+    }
+
     public record TypeParameterTargetImpl(TargetType targetType, int typeParameterIndex)
             implements TypeParameterTarget {
+
+        public TypeParameterTargetImpl(TargetType targetType, int typeParameterIndex) {
+            this.targetType = checkValid(targetType, TAT_CLASS_TYPE_PARAMETER, TAT_METHOD_TYPE_PARAMETER);
+            this.typeParameterIndex = typeParameterIndex;
+        }
     }
 
     public record SupertypeTargetImpl(int supertypeIndex) implements SupertypeTarget {
@@ -49,9 +63,19 @@ public final class TargetInfoImpl {
 
     public record TypeParameterBoundTargetImpl(TargetType targetType, int typeParameterIndex, int boundIndex)
             implements TypeParameterBoundTarget {
+
+        public TypeParameterBoundTargetImpl(TargetType targetType, int typeParameterIndex, int boundIndex) {
+            this.targetType = checkValid(targetType, TAT_CLASS_TYPE_PARAMETER_BOUND, TAT_METHOD_TYPE_PARAMETER_BOUND);
+            this.typeParameterIndex = typeParameterIndex;
+            this.boundIndex = boundIndex;
+        }
     }
 
     public record EmptyTargetImpl(TargetType targetType) implements EmptyTarget {
+
+        public EmptyTargetImpl(TargetType targetType) {
+            this.targetType = checkValid(targetType, TAT_FIELD, TAT_METHOD_RECEIVER);
+        }
     }
 
     public record FormalParameterTargetImpl(int formalParameterIndex) implements FormalParameterTarget {
@@ -70,6 +94,11 @@ public final class TargetInfoImpl {
 
     public record LocalVarTargetImpl(TargetType targetType, List<LocalVarTargetInfo> table)
             implements LocalVarTarget {
+
+        public LocalVarTargetImpl(TargetType targetType, List<LocalVarTargetInfo> table) {
+            this.targetType = checkValid(targetType, TAT_LOCAL_VARIABLE, TAT_RESOURCE_VARIABLE);
+            this.table = List.copyOf(table);
+        }
         @Override
         public int size() {
             return 2 + 6 * table.size();
@@ -88,9 +117,20 @@ public final class TargetInfoImpl {
     }
 
     public record OffsetTargetImpl(TargetType targetType, Label target) implements OffsetTarget {
+
+        public OffsetTargetImpl(TargetType targetType, Label target) {
+            this.targetType = checkValid(targetType, TAT_INSTANCEOF, TAT_METHOD_REFERENCE);
+            this.target = target;
+        }
     }
 
     public record TypeArgumentTargetImpl(TargetType targetType, Label target, int typeArgumentIndex)
             implements TypeArgumentTarget {
+
+        public TypeArgumentTargetImpl(TargetType targetType, Label target, int typeArgumentIndex) {
+            this.targetType = checkValid(targetType, TAT_CAST, TAT_METHOD_REFERENCE_TYPE_ARGUMENT);
+            this.target = target;
+            this.typeArgumentIndex = typeArgumentIndex;
+        }
     }
 }

--- a/test/jdk/jdk/classfile/helpers/RebuildingTransformation.java
+++ b/test/jdk/jdk/classfile/helpers/RebuildingTransformation.java
@@ -200,21 +200,17 @@ class RebuildingTransformation {
         return switch (av) {
             case AnnotationValue.OfAnnotation oa -> AnnotationValue.ofAnnotation(transformAnnotation(oa.annotation()));
             case AnnotationValue.OfArray oa -> AnnotationValue.ofArray(oa.values().stream().map(v -> transformAnnotationValue(v)).toArray(AnnotationValue[]::new));
-            case AnnotationValue.OfConstant oc -> //missing distinction between constant annotation value types
-                switch (oc.tag()) {
-                    case 's' -> AnnotationValue.of((String)oc.constantValue());
-                    case 'D' -> AnnotationValue.of((double)oc.constantValue());
-                    case 'F' -> AnnotationValue.of((float)oc.constantValue());
-                    case 'J' -> AnnotationValue.of((long)oc.constantValue());
-                    case 'I' -> AnnotationValue.of((int)oc.constantValue());
-                    case 'S' -> AnnotationValue.of((short)(int)oc.constantValue());
-                    case 'C' -> AnnotationValue.of((char)(int)oc.constantValue());
-                    case 'B' -> AnnotationValue.of((byte)(int)oc.constantValue());
-                    case 'Z' -> AnnotationValue.of(1 == (int)oc.constantValue());
-                    default ->  throw new AssertionError("Unexpected annotation value tag: " + oc.tag());
-                };
-            case AnnotationValue.OfClass oc -> AnnotationValue.ofClass(ClassDesc.ofDescriptor(oc.className().stringValue())); //missing AnnotationValue factory method accepting ClassDesc
-            case AnnotationValue.OfEnum oe -> AnnotationValue.ofEnum(ClassDesc.ofDescriptor(oe.className().stringValue()), oe.constantName().stringValue());  //missing AnnotationValue factory method accepting ClassDesc
+            case AnnotationValue.OfString v -> AnnotationValue.of(v.stringValue());
+            case AnnotationValue.OfDouble v -> AnnotationValue.of(v.doubleValue());
+            case AnnotationValue.OfFloat v -> AnnotationValue.of(v.floatValue());
+            case AnnotationValue.OfLong v -> AnnotationValue.of(v.longValue());
+            case AnnotationValue.OfInteger v -> AnnotationValue.of(v.intValue());
+            case AnnotationValue.OfShort v -> AnnotationValue.of(v.shortValue());
+            case AnnotationValue.OfCharacter v -> AnnotationValue.of(v.charValue());
+            case AnnotationValue.OfByte v -> AnnotationValue.of(v.byteValue());
+            case AnnotationValue.OfBoolean v -> AnnotationValue.of(v.booleanValue());
+            case AnnotationValue.OfClass oc -> AnnotationValue.of(oc.classSymbol());
+            case AnnotationValue.OfEnum oe -> AnnotationValue.ofEnum(oe.classSymbol(), oe.constantName().stringValue());
         };
     }
 
@@ -222,7 +218,7 @@ class RebuildingTransformation {
         return annotations.stream().map(ta -> TypeAnnotation.of( //missing TypeAnnotation factory method accepting ClassDesc and AnnotationElement vararg
                         transformTargetInfo(ta.targetInfo(), cob, labels),
                         ta.targetPath().stream().map(tpc -> TypeAnnotation.TypePathComponent.of(tpc.typePathKind().tag(), tpc.typeArgumentIndex())).toList(),
-                        ta.className(),
+                        ta.classSymbol(),
                         ta.elements().stream().map(ae -> AnnotationElement.of(ae.name().stringValue(), transformAnnotationValue(ae.value()))).toList())).toArray(TypeAnnotation[]::new);
     }
 


### PR DESCRIPTION
added TypeAnnotation factory methods accepting ClassDesc and AnnotationElement...
AnnotationValue.OfConstant sub-classed to allow switch pattern matching
added TypeAnnotation.TargetInfo factory methods with validity checking for multi-target types
RebuildingTransformation test helper adjusted