### PR TITLE
Model stack map frames in a type hierarchy where each type representsa frame type.

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/attribute/StackMapTableAttribute.java
+++ b/src/java.base/share/classes/jdk/classfile/attribute/StackMapTableAttribute.java
@@ -49,7 +49,7 @@ public sealed interface StackMapTableAttribute
     /**
      * {@return the initial frame}
      */
-    StackMapFrame initFrame();
+    StackMapFrame.Full initFrame();
 
     /**
      * The possible types for a stack slot.
@@ -144,16 +144,44 @@ public sealed interface StackMapTableAttribute
      * A stack map frame.
      */
     sealed interface StackMapFrame
-            permits StackMapDecoder.StackMapFrameImpl {
+            permits StackMapFrame.Same, StackMapFrame.Same1, StackMapFrame.Append, StackMapFrame.Chop, StackMapFrame.Full {
 
         int frameType();
         FrameKind frameKind();
         int offsetDelta();
-        List<VerificationTypeInfo> declaredLocals();
-        List<VerificationTypeInfo> declaredStack();
-
         int absoluteOffset();
         List<VerificationTypeInfo> effectiveLocals();
         List<VerificationTypeInfo> effectiveStack();
+
+        sealed interface Same extends StackMapFrame permits StackMapDecoder.StackMapFrameSameImpl {
+
+            boolean extended();
+        }
+        sealed interface Same1 extends StackMapFrame permits StackMapDecoder.StackMapFrameSame1Impl {
+
+            boolean extended();
+
+            VerificationTypeInfo declaredStack();
+        }
+
+        sealed interface Append extends StackMapFrame permits StackMapDecoder.StackMapFrameAppendImpl {
+
+            List<VerificationTypeInfo> declaredLocals();
+        }
+
+        sealed interface Chop extends StackMapFrame permits StackMapDecoder.StackMapFrameChopImpl {
+
+            List<VerificationTypeInfo> choppedLocals();
+        }
+
+        sealed interface Full extends StackMapFrame permits StackMapDecoder.StackMapFrameFullImpl {
+
+            default List<VerificationTypeInfo> declaredStack() {
+                return effectiveStack();
+            }
+            default List<VerificationTypeInfo> declaredLocals() {
+                return effectiveLocals();
+            }
+        }
     }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/BoundAttribute.java
@@ -230,7 +230,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
             implements StackMapTableAttribute {
         final MethodModel method;
         List<StackMapFrame> entries = null;
-        StackMapFrame initFrame = null;
+        StackMapFrame.Full initFrame = null;
 
         public BoundStackMapTableAttribute(CodeModel code, ClassReader cf, AttributeMapper<StackMapTableAttribute> mapper, int pos) {
             super(cf, mapper, pos);
@@ -238,7 +238,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
         }
 
         @Override
-        public StackMapFrame initFrame() {
+        public StackMapFrame.Full initFrame() {
             if (initFrame == null)
                 initFrame = StackMapDecoder.initFrame(method);
             return initFrame;

--- a/src/java.base/share/classes/jdk/classfile/impl/StackMapDecoder.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/StackMapDecoder.java
@@ -53,16 +53,16 @@ public class StackMapDecoder {
 
     private final ClassReader classReader;
     private final int pos;
-    private final StackMapFrame initFrame;
+    private final StackMapFrame.Full initFrame;
     private int p;
 
-    StackMapDecoder(ClassReader classReader, int pos, StackMapFrame initFrame) {
+    StackMapDecoder(ClassReader classReader, int pos, StackMapFrame.Full initFrame) {
         this.classReader = classReader;
         this.pos = pos;
         this.initFrame = initFrame;
     }
 
-    static StackMapFrame initFrame(MethodModel method) {
+    static StackMapFrame.Full initFrame(MethodModel method) {
         VerificationTypeInfo vtis[];
         var mdesc = method.descriptorSymbol();
         int i = 0;
@@ -87,45 +87,47 @@ public class StackMapDecoder {
                 default -> new StackMapDecoder.ObjectVerificationTypeInfoImpl(TemporaryConstantPool.INSTANCE.classEntry(arg));
             };
         }
-        return new StackMapFrameImpl(FULL, FrameKind.FULL_FRAME, -1, -1, List.of(vtis), List.of(), List.of(vtis), List.of());
+        return new StackMapFrameFullImpl(FULL, FrameKind.FULL_FRAME, -1, -1, List.of(vtis), List.of());
     }
 
     List<StackMapFrame> entries() {
         p = pos;
-        var frame = initFrame;
+        StackMapFrame frame = initFrame;
         var entries = new StackMapFrame[u2()];
         for (int ei = 0; ei < entries.length; ei++) {
             int frameType = classReader.readU1(p++);
             if (frameType < 64) {
-                frame = new StackMapFrameImpl(frameType, FrameKind.SAME,
+                frame = new StackMapFrameSameImpl(frameType, FrameKind.SAME,
                         frameType, frame.absoluteOffset() + frameType + 1,
-                        List.of(), List.of(),
+                        false,
                         frame.effectiveLocals(), List.of());
             } else if (frameType < 128) {
-                var stack = List.of(readVerificationTypeInfo());
-                frame = new StackMapFrameImpl(frameType, FrameKind.SAME_LOCALS_1_STACK_ITEM,
+                var stack = readVerificationTypeInfo();
+                frame = new StackMapFrameSame1Impl(frameType, FrameKind.SAME_LOCALS_1_STACK_ITEM,
                         frameType - 64, frame.absoluteOffset() + frameType - 63,
-                        List.of(), stack,
-                        frame.effectiveLocals(), stack);
+                        false,
+                        stack,
+                        frame.effectiveLocals(), List.of(stack));
             } else {
                 if (frameType < SAME_LOCALS_1_STACK_ITEM_EXTENDED)
                     throw new IllegalArgumentException("Invalid stackmap frame type: " + frameType);
                 int offsetDelta = u2();
                 if (frameType == SAME_LOCALS_1_STACK_ITEM_EXTENDED) {
-                    var stack = List.of(readVerificationTypeInfo());
-                    frame = new StackMapFrameImpl(frameType, FrameKind.SAME_LOCALS_1_STACK_ITEM_EXTENDED,
+                    var stack = readVerificationTypeInfo();
+                    frame = new StackMapFrameSame1Impl(frameType, FrameKind.SAME_LOCALS_1_STACK_ITEM_EXTENDED,
                             offsetDelta, frame.absoluteOffset() + offsetDelta + 1,
-                            List.of(), stack,
-                            frame.effectiveLocals(), stack);
+                            true,
+                            stack,
+                            frame.effectiveLocals(), List.of(stack));
                 } else if (frameType < SAME_EXTENDED) {
-                    frame = new StackMapFrameImpl(frameType, FrameKind.CHOP,
+                    frame = new StackMapFrameChopImpl(frameType, FrameKind.CHOP,
                             offsetDelta, frame.absoluteOffset() + offsetDelta + 1,
-                            List.of(), List.of(),
+                            frame.effectiveLocals().subList(frame.effectiveLocals().size() + frameType - SAME_EXTENDED, frame.effectiveLocals().size()),
                             frame.effectiveLocals().subList(0, frame.effectiveLocals().size() + frameType - SAME_EXTENDED), List.of());
                 } else if (frameType == SAME_EXTENDED) {
-                    frame = new StackMapFrameImpl(frameType, FrameKind.SAME_FRAME_EXTENDED,
+                    frame = new StackMapFrameSameImpl(frameType, FrameKind.SAME_FRAME_EXTENDED,
                             offsetDelta, frame.absoluteOffset() + offsetDelta + 1,
-                            List.of(), List.of(),
+                            true,
                             frame.effectiveLocals(), List.of());
                 } else if (frameType < SAME_EXTENDED + 4) {
                     int actSize = frame.effectiveLocals().size();
@@ -133,9 +135,9 @@ public class StackMapDecoder {
                     for (int i = actSize; i < locals.length; i++)
                         locals[i] = readVerificationTypeInfo();
                     var locList = List.of(locals);
-                    frame = new StackMapFrameImpl(frameType, FrameKind.APPEND,
+                    frame = new StackMapFrameAppendImpl(frameType, FrameKind.APPEND,
                             offsetDelta, frame.absoluteOffset() + offsetDelta + 1,
-                            locList.subList(actSize, locList.size()), List.of(),
+                            locList.subList(actSize, locList.size()),
                             locList, List.of());
                 } else {
                     var locals = new VerificationTypeInfo[u2()];
@@ -146,9 +148,8 @@ public class StackMapDecoder {
                         stack[i] = readVerificationTypeInfo();
                     var locList = List.of(locals);
                     var stackList = List.of(stack);
-                    frame = new StackMapFrameImpl(frameType, FrameKind.FULL_FRAME,
+                    frame = new StackMapFrameFullImpl(frameType, FrameKind.FULL_FRAME,
                             offsetDelta, frame.absoluteOffset() + offsetDelta + 1,
-                            locList, stackList,
                             locList, stackList);
                 }
             }
@@ -219,14 +220,53 @@ public class StackMapDecoder {
         return v;
     }
 
-    public static record StackMapFrameImpl(int frameType,
+    public static record StackMapFrameSameImpl(int frameType,
         FrameKind frameKind,
         int offsetDelta,
         int absoluteOffset,
-        List<VerificationTypeInfo> declaredLocals,
-        List<VerificationTypeInfo> declaredStack,
+        boolean extended,
         List<VerificationTypeInfo> effectiveLocals,
         List<VerificationTypeInfo> effectiveStack)
-            implements StackMapFrame {
+            implements StackMapFrame.Same {
+    }
+
+    public static record StackMapFrameSame1Impl(int frameType,
+                                               FrameKind frameKind,
+                                               int offsetDelta,
+                                               int absoluteOffset,
+                                               boolean extended,
+                                               VerificationTypeInfo declaredStack,
+                                               List<VerificationTypeInfo> effectiveLocals,
+                                               List<VerificationTypeInfo> effectiveStack)
+            implements StackMapFrame.Same1 {
+    }
+
+    public static record StackMapFrameAppendImpl(int frameType,
+                                                 FrameKind frameKind,
+                                                 int offsetDelta,
+                                                 int absoluteOffset,
+                                                 List<VerificationTypeInfo> declaredLocals,
+                                                 List<VerificationTypeInfo> effectiveLocals,
+                                                 List<VerificationTypeInfo> effectiveStack)
+            implements StackMapFrame.Append {
+    }
+
+    public static record StackMapFrameChopImpl(int frameType,
+                                                 FrameKind frameKind,
+                                                 int offsetDelta,
+                                                 int absoluteOffset,
+                                                 List<VerificationTypeInfo> choppedLocals,
+                                                 List<VerificationTypeInfo> effectiveLocals,
+                                                 List<VerificationTypeInfo> effectiveStack)
+            implements StackMapFrame.Chop {
+    }
+
+    public static record StackMapFrameFullImpl(int frameType,
+                                               FrameKind frameKind,
+                                               int offsetDelta,
+                                               int absoluteOffset,
+                                               List<VerificationTypeInfo> effectiveLocals,
+                                               List<VerificationTypeInfo> effectiveStack)
+            implements StackMapFrame.Full {
     }
 }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -534,52 +534,56 @@ public class AttributeWriter extends BasicWriter {
                 println("StackMapTable: number_of_entries = " + entries.size());
                 indent(+1);
                 for (var frame : entries) {
-                    switch (frame.frameKind()) {
-                        case SAME ->
-                            printHeader(frame, "/* same */");
-                        case SAME_LOCALS_1_STACK_ITEM -> {
-                            printHeader(frame, "/* same_locals_1_stack_item */");
+                    switch (frame) {
+                        case StackMapTableAttribute.StackMapFrame.Same same -> {
+                            if (same.extended()) {
+                                printHeader(same, "/* same_frame_extended */");
+                                indent(+1);
+                                println("offset_delta = " + same.offsetDelta());
+                                indent(-1);
+                            } else {
+                                printHeader(same, "/* same */");
+                            }
+                        }
+                        case StackMapTableAttribute.StackMapFrame.Same1 same1 -> {
+                            if (same1.extended()) {
+                                printHeader(same1, "/* same_locals_1_stack_item_frame_extended */");
+                                indent(+1);
+                                println("offset_delta = " + same1.offsetDelta());
+                                printMap("stack", List.of(same1.declaredStack()));
+                                indent(-1);
+                            } else {
+                                printHeader(same1, "/* same_locals_1_stack_item */");
+                                indent(+1);
+                                printMap("stack", List.of(same1.declaredStack()));
+                                indent(-1);
+                            }
+                        }
+                        case StackMapTableAttribute.StackMapFrame.Chop chop -> {
+                            printHeader(chop, "/* chop */");
                             indent(+1);
-                            printMap("stack", frame.declaredStack());
+                            println("offset_delta = " + chop.offsetDelta());
+                            printMap("locals", chop.choppedLocals());
                             indent(-1);
                         }
-                        case SAME_LOCALS_1_STACK_ITEM_EXTENDED -> {
-                            printHeader(frame, "/* same_locals_1_stack_item_frame_extended */");
+                        case StackMapTableAttribute.StackMapFrame.Append append -> {
+                            printHeader(append, "/* append */");
                             indent(+1);
-                            println("offset_delta = " + frame.offsetDelta());
-                            printMap("stack", frame.declaredStack());
+                            println("offset_delta = " + append.offsetDelta());
+                            printMap("locals", append.declaredLocals());
                             indent(-1);
                         }
-                        case CHOP -> {
-                            printHeader(frame, "/* chop */");
-                            indent(+1);
-                            println("offset_delta = " + frame.offsetDelta());
-                            indent(-1);
-                        }
-                        case SAME_FRAME_EXTENDED -> {
-                            printHeader(frame, "/* same_frame_extended */");
-                            indent(+1);
-                            println("offset_delta = " + frame.offsetDelta());
-                            indent(-1);
-                        }
-                        case APPEND -> {
-                            printHeader(frame, "/* append */");
-                            indent(+1);
-                            println("offset_delta = " + frame.offsetDelta());
-                            printMap("locals", frame.declaredLocals());
-                            indent(-1);
-                        }
-                        case FULL_FRAME -> {
+                        case StackMapTableAttribute.StackMapFrame.Full full -> {
 //full frame used in StackMapAttribute
 //                            if (frame instanceof StackMap_attribute.stack_map_frame) {
-//                                printHeader(frame, "offset = " + frame.offset_delta);
+//                                printHeader(full, "offset = " + full.offset_delta);
 //                                indent(+1);
 //                            } else {
-                            printHeader(frame, "/* full_frame */");
+                            printHeader(full, "/* full_frame */");
                             indent(+1);
-                            println("offset_delta = " + frame.offsetDelta());
-                            printMap("locals", frame.declaredLocals());
-                            printMap("stack", frame.declaredStack());
+                            println("offset_delta = " + full.offsetDelta());
+                            printMap("locals", full.declaredLocals());
+                            printMap("stack", full.declaredStack());
                             indent(-1);
                         }
                     }


### PR DESCRIPTION
Doing so, make the chop size available to consumers of frames. 

If one is interested in the declared properties, it is already required to interpret the frame type and by this model, only meaningful declared properties are available. If one does not care about the frame type, effective stack and locals are still available on all frame types.