### PR TITLE
Adds toString methods to all classes that appear within a CodeModel.

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/impl/AbstractAttributeMapper.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/AbstractAttributeMapper.java
@@ -102,4 +102,10 @@ public abstract class AbstractAttributeMapper<T extends Attribute<T>>
     public int validSince() {
         return majorVersion;
     }
+
+    @Override
+    public String toString() {
+        return String.format("AttributeMapper[name=%s, allowMultiple=%b, validSince=%d, whereApplicable=%s]",
+                name, allowMultiple, majorVersion, whereApplicable);
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/AbstractInstruction.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/AbstractInstruction.java
@@ -1392,6 +1392,11 @@ public abstract sealed class AbstractInstruction
         public void writeTo(DirectCodeBuilder writer) {
             writer.addHandler(this);
         }
+
+        @Override
+        public String toString() {
+            return String.format("ExceptionCatch[catchType=%s]", catchTypeEntry == null ? "<any>" : catchTypeEntry.name().stringValue());
+        }
     }
 
     public static final class UnboundCharacterRange

--- a/src/java.base/share/classes/jdk/classfile/impl/AccessFlagsImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/AccessFlagsImpl.java
@@ -84,4 +84,9 @@ public final class AccessFlagsImpl extends AbstractElement
     public boolean has(AccessFlag flag) {
         return Util.has(location, flagsMask, flag);
     }
+
+    @Override
+    public String toString() {
+        return String.format("AccessFlags[flags=%d]", flagsMask);
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/BoundAttribute.java
@@ -111,6 +111,11 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
         return classReader;
     }
 
+    @Override
+    public String toString() {
+        return String.format("Attribute[name=%s]", mapper.name());
+    }
+
     <E> List<E> readEntryList(int p) {
         // @@@ Could use JavaUtilCollectionAccess.listFromTrustedArrayNullsAllowed to avoid copy
         int cnt = classReader.readU2(p);

--- a/src/java.base/share/classes/jdk/classfile/impl/BoundCharacterRange.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/BoundCharacterRange.java
@@ -94,4 +94,10 @@ public final class BoundCharacterRange
     public int sizeInBytes() {
         return 0;
     }
+
+    @Override
+    public String toString() {
+        return String.format("CharacterRange[startScope=%s, endScope=%s, characterRangeStart=%s, characterRangeEnd=%s, flags=%d]",
+                startScope(), endScope(), characterRangeStart(), characterRangeEnd(), flags());
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/BoundLocalVariable.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/BoundLocalVariable.java
@@ -56,4 +56,9 @@ public final class BoundLocalVariable
     public void writeTo(DirectCodeBuilder writer) {
         writer.addLocalVariable(this);
     }
+
+    @Override
+    public String toString() {
+        return String.format("LocalVariable[name=%s, slot=%d, type=%s]", name().stringValue(), slot(), type().stringValue());
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/BoundLocalVariableType.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/BoundLocalVariableType.java
@@ -55,4 +55,9 @@ public final class BoundLocalVariableType
     public void writeTo(DirectCodeBuilder writer) {
         writer.addLocalVariableType(this);
     }
+
+    @Override
+    public String toString() {
+        return String.format("LocalVariableType[name=%s, slot=%d, signature=%s]", name().stringValue(), slot(), signature().stringValue());
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/BufferedCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/BufferedCodeBuilder.java
@@ -139,6 +139,11 @@ public final class BufferedCodeBuilder
         return this;
     }
 
+    @Override
+    public String toString() {
+        return String.format("CodeModel[id=%d]", System.identityHashCode(this));
+    }
+
     public BufferedCodeBuilder run(Consumer<? super CodeBuilder> handler) {
         handler.accept(this);
         return this;
@@ -208,6 +213,11 @@ public final class BufferedCodeBuilder
 
         public void writeTo(BufWriter buf) {
             DirectCodeBuilder.build(methodInfo, cb -> elements.forEach(cb), constantPool, null).writeTo(buf);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("CodeModel[id=%s]", Integer.toHexString(System.identityHashCode(this)));
         }
     }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/BufferedFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/BufferedFieldBuilder.java
@@ -116,5 +116,10 @@ public final class BufferedFieldBuilder
             elements.forEach(fb);
             fb.writeTo(buf);
         }
+
+        @Override
+        public String toString() {
+            return String.format("FieldModel[fieldName=%s, fieldType=%s, flags=%d]", name.stringValue(), desc.stringValue(), flags.flagsMask());
+        }
     }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/BufferedMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/BufferedMethodBuilder.java
@@ -196,5 +196,11 @@ public final class BufferedMethodBuilder
             elements.forEach(mb);
             mb.writeTo(buf);
         }
+
+        @Override
+        public String toString() {
+            return String.format("MethodModel[methodName=%s, methodType=%s, flags=%d]",
+                    name.stringValue(), desc.stringValue(), flags.flagsMask());
+        }
     }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/ClassImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/ClassImpl.java
@@ -214,6 +214,11 @@ public final class ClassImpl
                && verifyModuleAttributes();
     }
 
+    @Override
+    public String toString() {
+        return String.format("ClassModel[thisClass=%s, flags=%d]", thisClass().name().stringValue(), flags().flagsMask());
+    }
+
     private boolean verifyModuleAttributes() {
         if (findAttribute(Attributes.MODULE).isEmpty())
             return false;

--- a/src/java.base/share/classes/jdk/classfile/impl/ClassfileVersionImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/ClassfileVersionImpl.java
@@ -53,4 +53,9 @@ public final class ClassfileVersionImpl
     public void writeTo(DirectClassBuilder builder) {
         builder.setVersion(majorVersion, minorVersion);
     }
+
+    @Override
+    public String toString() {
+        return String.format("ClassfileVersion[majorVersion=%d, minorVersion=%d]", majorVersion, minorVersion);
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/CodeImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/CodeImpl.java
@@ -499,4 +499,9 @@ public final class CodeImpl
             }
         };
     }
+
+    @Override
+    public String toString() {
+        return String.format("CodeModel[id=%d]", System.identityHashCode(this));
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/DirectCodeBuilder.java
@@ -691,6 +691,11 @@ public final class DirectCodeBuilder
         localVariableTypes.add(element);
     }
 
+    @Override
+    public String toString() {
+        return String.format("CodeBuilder[id=%d]", System.identityHashCode(this));
+    }
+
     //ToDo: consolidate and open all exceptions
     private static final class LabelOverflowException extends IllegalStateException {
 

--- a/src/java.base/share/classes/jdk/classfile/impl/FieldImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/FieldImpl.java
@@ -125,4 +125,10 @@ public final class FieldImpl
                 consumer.accept(e);
         }
     }
+
+    @Override
+    public String toString() {
+        return String.format("FieldModel[fieldName=%s, fieldType=%s, flags=%d]",
+                fieldName().stringValue(), fieldType().stringValue(), flags().flagsMask());
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/InterfacesImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/InterfacesImpl.java
@@ -25,6 +25,7 @@
 package jdk.classfile.impl;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import jdk.classfile.constantpool.ClassEntry;
 import jdk.classfile.Interfaces;
@@ -49,5 +50,12 @@ public final class InterfacesImpl
     @Override
     public void writeTo(DirectClassBuilder builder) {
         builder.setInterfaces(interfaces);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Interfaces[interfaces=%s]", interfaces.stream()
+                .map(iface -> iface.name().stringValue())
+                .collect(Collectors.joining(", ")));
     }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/LineNumberImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/LineNumberImpl.java
@@ -76,5 +76,10 @@ public final class LineNumberImpl
     public void writeTo(DirectCodeBuilder writer) {
         writer.setLineNumber(line);
     }
+
+    @Override
+    public String toString() {
+        return String.format("LineNumber[line=%d]", line);
+    }
 }
 

--- a/src/java.base/share/classes/jdk/classfile/impl/MethodImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/MethodImpl.java
@@ -145,4 +145,10 @@ public final class MethodImpl
             });
         }
     }
+
+    @Override
+    public String toString() {
+        return String.format("MethodModel[methodName=%s, methodType=%s, flags=%d]",
+                methodName().stringValue(), methodType().stringValue(), flags().flagsMask());
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/SuperclassImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/SuperclassImpl.java
@@ -51,4 +51,9 @@ public final class SuperclassImpl
     public void writeTo(DirectClassBuilder builder) {
         builder.setSuperclass(superclassEntry);
     }
+
+    @Override
+    public String toString() {
+        return String.format("Superclass[superclassEntry=%s]", superclassEntry.name().stringValue());
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/UnboundAttribute.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/UnboundAttribute.java
@@ -140,6 +140,10 @@ public abstract sealed class UnboundAttribute<T extends Attribute<T>>
         builder.writeAttribute(this);
     }
 
+    @Override
+    public String toString() {
+        return String.format("Attribute[name=%s]", mapper.name());
+    }
     public static final class UnboundConstantValueAttribute
             extends UnboundAttribute<ConstantValueAttribute>
             implements ConstantValueAttribute {


### PR DESCRIPTION
All values that can be reached via a `ClassModel` should have a meaningful `toString` representation to allow for easier debugging of code models. Class models are a rather large object tree what makes debugger navigation a common option where it is currently confusing to jump between class names and explicit `toString` implementations.