### PR TITLE
Add factory methods for module export/open info that is based on descriptors rather than entries

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/Opcode.java
+++ b/src/java.base/share/classes/jdk/classfile/Opcode.java
@@ -260,6 +260,17 @@ public enum Opcode {
     END(0xFF09, 0, CodeElement.Kind.END),
     ;
 
+    private static final Opcode[] OPCODES_BY_BYTECODE;
+
+    static {
+        OPCODES_BY_BYTECODE = new Opcode[202];
+        for (Opcode opcode : values()) {
+            if (opcode.bytecode < OPCODES_BY_BYTECODE.length) {
+                OPCODES_BY_BYTECODE[opcode.bytecode] = opcode;
+            }
+        }
+    }
+
     private final int bytecode;
     private final int sizeIfFixed;
     private final CodeElement.Kind kind;
@@ -302,6 +313,13 @@ public enum Opcode {
         this.secondaryTypeKind = secondaryTypeKind;
         this.slot = slot;
         this.constantValue = constantValue;
+    }
+
+    public static Opcode ofBytecode(int bytecode) {
+        if (bytecode < 0 || bytecode >= OPCODES_BY_BYTECODE.length) {
+            throw new IllegalArgumentException("Not a bytecode: " + bytecode);
+        }
+        return OPCODES_BY_BYTECODE[bytecode];
     }
     
     public int bytecode() { return bytecode; }

--- a/src/java.base/share/classes/jdk/classfile/attribute/ModuleExportInfo.java
+++ b/src/java.base/share/classes/jdk/classfile/attribute/ModuleExportInfo.java
@@ -31,10 +31,14 @@ import java.util.Set;
 import jdk.classfile.constantpool.ModuleEntry;
 import jdk.classfile.constantpool.PackageEntry;
 import java.lang.reflect.AccessFlag;
+import java.util.stream.Collectors;
 
 import jdk.classfile.Classfile;
+import jdk.classfile.impl.TemporaryConstantPool;
 import jdk.classfile.impl.UnboundAttribute;
 import jdk.classfile.impl.Util;
+import jdk.classfile.jdktypes.ModuleDesc;
+import jdk.classfile.jdktypes.PackageDesc;
 
 /**
  * Models a single "exports" declaration in the {@link jdk.classfile.attribute.ModuleAttribute}.
@@ -119,6 +123,58 @@ public sealed interface ModuleExportInfo
     static ModuleExportInfo of(PackageEntry exports,
                                Collection<AccessFlag> exportFlags,
                                ModuleEntry... exportsTo) {
+        return of(exports, Util.flagsToBits(AccessFlag.Location.MODULE_EXPORTS, exportFlags), exportsTo);
+    }
+
+    /**
+     * {@return a module export description}
+     * @param exports the exported package
+     * @param exportFlags the export flags
+     * @param exportsTo the modules to which this package is exported
+     */
+    static ModuleExportInfo of(PackageDesc exports,
+                               int exportFlags,
+                               List<ModuleDesc> exportsTo) {
+        return new UnboundAttribute.UnboundModuleExportInfo(TemporaryConstantPool.INSTANCE.packageEntry(TemporaryConstantPool.INSTANCE.utf8Entry(exports.packageName())),
+                exportFlags,
+                exportsTo.stream().map(e -> TemporaryConstantPool.INSTANCE.moduleEntry(TemporaryConstantPool.INSTANCE.utf8Entry(e.moduleName()))).collect(Collectors.toList()));
+    }
+
+    /**
+     * {@return a module export description}
+     * @param exports the exported package
+     * @param exportFlags the export flags
+     * @param exportsTo the modules to which this package is exported
+     */
+    static ModuleExportInfo of(PackageDesc exports,
+                               Collection<AccessFlag> exportFlags,
+                               List<ModuleDesc> exportsTo) {
+        return of(exports,
+                Util.flagsToBits(AccessFlag.Location.MODULE_EXPORTS, exportFlags),
+                exportsTo);
+    }
+
+    /**
+     * {@return a module export description}
+     * @param exports the exported package
+     * @param exportFlags the export flags
+     * @param exportsTo the modules to which this package is exported
+     */
+    static ModuleExportInfo of(PackageDesc exports,
+                               int exportFlags,
+                               ModuleDesc... exportsTo) {
+        return of(exports, exportFlags, List.of(exportsTo));
+    }
+
+    /**
+     * {@return a module export description}
+     * @param exports the exported package
+     * @param exportFlags the export flags
+     * @param exportsTo the modules to which this package is exported
+     */
+    static ModuleExportInfo of(PackageDesc exports,
+                               Collection<AccessFlag> exportFlags,
+                               ModuleDesc... exportsTo) {
         return of(exports, Util.flagsToBits(AccessFlag.Location.MODULE_EXPORTS, exportFlags), exportsTo);
     }
 }

--- a/src/java.base/share/classes/jdk/classfile/attribute/ModuleOpenInfo.java
+++ b/src/java.base/share/classes/jdk/classfile/attribute/ModuleOpenInfo.java
@@ -31,9 +31,13 @@ import java.util.Set;
 import jdk.classfile.constantpool.ModuleEntry;
 import jdk.classfile.constantpool.PackageEntry;
 import java.lang.reflect.AccessFlag;
+import java.util.stream.Collectors;
 
+import jdk.classfile.impl.TemporaryConstantPool;
 import jdk.classfile.impl.UnboundAttribute;
 import jdk.classfile.impl.Util;
+import jdk.classfile.jdktypes.ModuleDesc;
+import jdk.classfile.jdktypes.PackageDesc;
 
 /**
  * Models a single "opens" declaration in the {@link jdk.classfile.attribute.ModuleAttribute}.
@@ -114,6 +118,58 @@ public sealed interface ModuleOpenInfo
     static ModuleOpenInfo of(PackageEntry opens,
                              Collection<AccessFlag> opensFlags,
                              ModuleEntry... opensTo) {
+        return of(opens, Util.flagsToBits(AccessFlag.Location.MODULE_OPENS, opensFlags), opensTo);
+    }
+
+    /**
+     * {@return a module open description}
+     * @param opens the package to open
+     * @param opensFlags the open flags
+     * @param opensTo the packages to which this package is opened, if it is a qualified open
+     */
+    static ModuleOpenInfo of(PackageDesc opens,
+                             int opensFlags,
+                             List<ModuleDesc> opensTo) {
+        return new UnboundAttribute.UnboundModuleOpenInfo(TemporaryConstantPool.INSTANCE.packageEntry(TemporaryConstantPool.INSTANCE.utf8Entry(opens.packageName())),
+                opensFlags,
+                opensTo.stream().map(o -> TemporaryConstantPool.INSTANCE.moduleEntry(TemporaryConstantPool.INSTANCE.utf8Entry(o.moduleName()))).collect(Collectors.toList()));
+    }
+
+    /**
+     * {@return a module open description}
+     * @param opens the package to open
+     * @param opensFlags the open flags
+     * @param opensTo the packages to which this package is opened, if it is a qualified open
+     */
+    static ModuleOpenInfo of(PackageDesc opens,
+                             Collection<AccessFlag> opensFlags,
+                             List<ModuleDesc> opensTo) {
+        return of(opens,
+                Util.flagsToBits(AccessFlag.Location.MODULE_OPENS, opensFlags),
+                opensTo);
+    }
+
+    /**
+     * {@return a module open description}
+     * @param opens the package to open
+     * @param opensFlags the open flags
+     * @param opensTo the packages to which this package is opened, if it is a qualified open
+     */
+    static ModuleOpenInfo of(PackageDesc opens,
+                             int opensFlags,
+                             ModuleDesc... opensTo) {
+        return of(opens, opensFlags, List.of(opensTo));
+    }
+
+    /**
+     * {@return a module open description}
+     * @param opens the package to open
+     * @param opensFlags the open flags
+     * @param opensTo the packages to which this package is opened, if it is a qualified open
+     */
+    static ModuleOpenInfo of(PackageDesc opens,
+                             Collection<AccessFlag> opensFlags,
+                             ModuleDesc... opensTo) {
         return of(opens, Util.flagsToBits(AccessFlag.Location.MODULE_OPENS, opensFlags), opensTo);
     }
 }


### PR DESCRIPTION
Allow to lookup opcode by bytecode to ease interaction with other byte code processors that provide bytecode values.