### PR TITLE
Allow for writing line numbers at a later code offset by optionally providing a label that indicates for where the line number should be set.

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/jdk/classfile/CodeBuilder.java
@@ -486,6 +486,12 @@ public sealed interface CodeBuilder
         return this;
     }
 
+    default CodeBuilder lineNumber(int line, Label label) {
+        requireNonNull(label);
+        with(LineNumberImpl.of(line, label));
+        return this;
+    }
+
     default CodeBuilder exceptionCatch(Label start, Label end, Label handler, ClassEntry catchType) {
         requireNonNull(catchType);
         with(ExceptionCatch.of(handler, start, end, catchType));

--- a/src/java.base/share/classes/jdk/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/DirectCodeBuilder.java
@@ -625,10 +625,10 @@ public final class DirectCodeBuilder
         }
     }
 
-    public void setLineNumber(int lineNo) {
+    public void setLineNumber(int lineNo, Label label) {
         if (lineNumberWriter == null)
             lineNumberWriter = new DedupLineNumberTableAttribute(constantPool);
-        lineNumberWriter.writeLineNumber(curPc(), lineNo);
+        lineNumberWriter.writeLineNumber(label == null ? this.curPc() : labelToBci(label), lineNo);
     }
 
     public void setLabelTarget(Label label) {

--- a/src/java.base/share/classes/jdk/classfile/impl/LineNumberImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/LineNumberImpl.java
@@ -24,6 +24,9 @@
  */
 package jdk.classfile.impl;
 
+import java.util.Optional;
+
+import jdk.classfile.Label;
 import jdk.classfile.Opcode;
 import jdk.classfile.instruction.LineNumber;
 
@@ -37,24 +40,34 @@ public final class LineNumberImpl
     private static final LineNumber[] internCache = new LineNumber[INTERN_LIMIT];
     static {
         for (int i=0; i<INTERN_LIMIT; i++)
-            internCache[i] = new LineNumberImpl(i);
+            internCache[i] = new LineNumberImpl(i, null);
     }
 
     private final int line;
+    private final Label label;
 
-    private LineNumberImpl(int line) {
+    private LineNumberImpl(int line, Label label) {
         this.line = line;
+        this.label = label;
     }
 
     public static LineNumber of(int line) {
         return (line < INTERN_LIMIT)
                ? internCache[line]
-               : new LineNumberImpl(line);
+               : new LineNumberImpl(line, null);
+    }
+
+    public static LineNumber of(int line, Label label) {
+        return new LineNumberImpl(line, label);
     }
 
     @Override
     public int line() {
         return line;
+    }
+
+    public Optional<Label> label() {
+        return Optional.ofNullable(label);
     }
 
     @Override
@@ -74,12 +87,12 @@ public final class LineNumberImpl
 
     @Override
     public void writeTo(DirectCodeBuilder writer) {
-        writer.setLineNumber(line);
+        writer.setLineNumber(line, label);
     }
 
     @Override
     public String toString() {
-        return String.format("LineNumber[line=%d]", line);
+        return String.format("LineNumber[line=%d,label=%s]", line, label);
     }
 }
 

--- a/src/java.base/share/classes/jdk/classfile/instruction/LineNumber.java
+++ b/src/java.base/share/classes/jdk/classfile/instruction/LineNumber.java
@@ -24,9 +24,12 @@
  */
 package jdk.classfile.instruction;
 
+import java.util.Optional;
+
 import jdk.classfile.Classfile;
 import jdk.classfile.CodeElement;
 import jdk.classfile.CodeModel;
+import jdk.classfile.Label;
 import jdk.classfile.PseudoInstruction;
 import jdk.classfile.attribute.CharacterRangeTableAttribute;
 import jdk.classfile.attribute.LineNumberTableAttribute;
@@ -43,4 +46,12 @@ import jdk.classfile.impl.LineNumberImpl;
 sealed public interface LineNumber extends PseudoInstruction
         permits LineNumberImpl {
     int line();
+
+    /**
+     * Returns the label that marks the position of the line number. If no
+     * such label is set, the line number marks the current position.
+     *
+     * @return The label for the specified line number, if defined.
+     */
+    Optional<Label> label();
 }


### PR DESCRIPTION
In some scenarios, the line numbers are only defined after writing the code. This is not a problem since line numbers are stored in a custom attribute. This also aligns better with the existing API in ASM what would ease migration.