### PR TITLE
Allows to add an offset to bound labels to mark code positions in code that was already added to a builder.

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/jdk/classfile/CodeBuilder.java
@@ -476,6 +476,13 @@ public sealed interface CodeBuilder
         return label;
     }
 
+    default Label newBoundLabel(int offset) {
+        LabelImpl label = (LabelImpl) newLabel();
+        label.setOffset(offset);
+        labelBinding(label);
+        return label;
+    }
+
     default CodeBuilder labelBinding(Label label) {
         with((LabelImpl) label);
         return this;

--- a/src/java.base/share/classes/jdk/classfile/impl/LabelImpl.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/LabelImpl.java
@@ -51,6 +51,7 @@ public final class LabelImpl
 
     private final LabelContext labelContext;
     private int contextInfo;
+    private int offset;
 
     public LabelImpl(LabelContext labelContext, int contextInfo) {
         this.labelContext = Objects.requireNonNull(labelContext);
@@ -67,6 +68,10 @@ public final class LabelImpl
 
     public void setContextInfo(int contextInfo) {
         this.contextInfo = contextInfo;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
     }
 
     @Override
@@ -91,7 +96,7 @@ public final class LabelImpl
 
     @Override
     public void writeTo(DirectCodeBuilder builder) {
-        builder.setLabelTarget(this);
+        builder.setLabelTarget(this, builder.curPc() - offset);
     }
 
     @Override


### PR DESCRIPTION
This allows to keep track of previously written instructions if a label should be added after that instruction was already added. This way, it is not necessary to add labels only in case it is needed at a later point.