### PR TITLE
Adjust javap implementation to be identical to its ASM-based implementation.

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AnnotationWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AnnotationWriter.java
@@ -115,7 +115,7 @@ public class AnnotationWriter extends BasicWriter {
             case TypeAnnotation.OffsetTarget pos -> {
                 if (showOffsets) {
                     print(", offset=");
-                    print(pos.target());
+                    print(lr.labelToBci(pos.target()));
                 }
             }
             case TypeAnnotation.LocalVarTarget pos -> {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -203,8 +203,9 @@ public class AttributeWriter extends BasicWriter {
                             indent(+1);
                             first = false;
                         }
+                        boolean isInterface = info.flags().contains(AccessFlag.INTERFACE);
                         for (var flag : info.flags())
-                            if (flag.sourceModifier()) print(Modifier.toString(flag.mask()) + " ");
+                            if (flag.sourceModifier() && (!isInterface || flag != AccessFlag.ABSTRACT)) print(Modifier.toString(flag.mask()) + " ");
                         if (info.innerName().isPresent()) {
                             print("#" + info.innerName().get().index() + "= ");
                         }
@@ -563,7 +564,7 @@ public class AttributeWriter extends BasicWriter {
                             printHeader(chop, "/* chop */");
                             indent(+1);
                             println("offset_delta = " + chop.offsetDelta());
-                            printMap("locals", chop.choppedLocals());
+                            println("slots = " + chop.choppedLocals().size());
                             indent(-1);
                         }
                         case StackMapTableAttribute.StackMapFrame.Append append -> {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import jdk.classfile.Classfile;
 import jdk.classfile.CodeModel;
+import jdk.classfile.Opcode;
 import jdk.classfile.constantpool.*;
 import jdk.classfile.Instruction;
 import jdk.classfile.MethodModel;
@@ -128,7 +129,7 @@ public class CodeWriter extends BasicWriter {
             case InvokeDynamicInstruction instr ->
                 printConstantPoolRefAndValue(instr.invokedynamic(), 0);
             case InvokeInstruction instr -> {
-                if (instr.isInterface()) printConstantPoolRefAndValue(instr.method(), instr.count());
+                if (instr.isInterface() && instr.opcode() != Opcode.INVOKESTATIC) printConstantPoolRefAndValue(instr.method(), instr.count());
                 else printConstantPoolRef(instr.method());
             }
             case LoadInstruction instr ->

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ConstantWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ConstantWriter.java
@@ -80,7 +80,7 @@ public class ConstantWriter extends BasicWriter {
                     println("// " + stringValue(info));
                 }
                 case DynamicConstantPoolEntry info -> {
-                    print("#" + info.bootstrap().bootstrapMethod().index() + ":#" + info.nameAndType().index());
+                    print("#" + info.bootstrap().bsmIndex() + ":#" + info.nameAndType().index());
                     tab();
                     println("// " + stringValue(info));
                 }
@@ -236,7 +236,20 @@ public class ConstantWriter extends BasicWriter {
             case ModuleEntry info -> checkName(info.name().stringValue());
             case NameAndTypeEntry info -> checkName(info.name().stringValue()) + ':' + info.type().stringValue();
             case PackageEntry info -> checkName(info.name().stringValue());
-            case MethodHandleEntry info -> info.asSymbol().kind() + " " + stringValue(info.reference());
+            case MethodHandleEntry info -> {
+                String kind = switch (info.asSymbol().kind()) {
+                    case STATIC, INTERFACE_STATIC -> "REF_invokeStatic";
+                    case VIRTUAL -> "REF_invokeVirtual";
+                    case INTERFACE_VIRTUAL -> "REF_invokeInterface";
+                    case SPECIAL, INTERFACE_SPECIAL -> "REF_invokeSpecial";
+                    case CONSTRUCTOR -> "REF_newInvokeSpecial";
+                    case GETTER -> "REF_getField";
+                    case SETTER -> "REF_putField";
+                    case STATIC_GETTER -> "REF_getStatic";
+                    case STATIC_SETTER -> "REF_putStatic";
+                };
+                yield kind + " " + stringValue(info.reference());
+            }
             case MethodTypeEntry info -> info.descriptor().stringValue();
             case StringEntry info -> stringValue(info.utf8());
             case Utf8Entry info -> {


### PR DESCRIPTION
1. Never print labels but byte code offsets.
2. Do not print the (implicit) abstract flag for inner interfaces or annotations.
3. Do not print the count for static invocations on interfaces.
4. Print the JVMS "REF" value for method handle entries instead of the enum name. (Arguably, the enum name contains more information if a target is an interface, but those constants are not mentioned in the specification, this is why I found them confusing when using javap.)
5. Use the "bsmIndex" for dynamic constant pool entries.
6. Do not print interpreted data when displaying frames. (Even in previous 'javap' versions, the *chop* frame display did not mention the number of reduced slots, but a class file does not contain the types of frames that are chopped, only the amount. Therefore, I think it is more correct to display this amount rather than the interpreted data.)