### PR TITLE
Adjust javap implementation to be identical to its ASM-based implementation.

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AnnotationWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AnnotationWriter.java
@@ -115,7 +115,7 @@ public class AnnotationWriter extends BasicWriter {
             case TypeAnnotation.OffsetTarget pos -> {
                 if (showOffsets) {
                     print(", offset=");
-                    print(pos.target());
+                    print(lr.labelToBci(pos.target()));
                 }
             }
             case TypeAnnotation.LocalVarTarget pos -> {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -203,8 +203,9 @@ public class AttributeWriter extends BasicWriter {
                             indent(+1);
                             first = false;
                         }
+                        boolean isInterface = info.flags().contains(AccessFlag.INTERFACE);
                         for (var flag : info.flags())
-                            if (flag.sourceModifier()) print(Modifier.toString(flag.mask()) + " ");
+                            if (flag.sourceModifier() && (!isInterface || flag != AccessFlag.ABSTRACT)) print(Modifier.toString(flag.mask()) + " ");
                         if (info.innerName().isPresent()) {
                             print("#" + info.innerName().get().index() + "= ");
                         }
@@ -563,7 +564,7 @@ public class AttributeWriter extends BasicWriter {
                             printHeader(chop, "/* chop */");
                             indent(+1);
                             println("offset_delta = " + chop.offsetDelta());
-                            printMap("locals", chop.choppedLocals());
+                            println("slots = " + chop.choppedLocals().size());
                             indent(-1);
                         }
                         case StackMapTableAttribute.StackMapFrame.Append append -> {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import jdk.classfile.Classfile;
 import jdk.classfile.CodeModel;
+import jdk.classfile.Opcode;
 import jdk.classfile.constantpool.*;
 import jdk.classfile.Instruction;
 import jdk.classfile.MethodModel;
@@ -128,7 +129,7 @@ public class CodeWriter extends BasicWriter {
             case InvokeDynamicInstruction instr ->
                 printConstantPoolRefAndValue(instr.invokedynamic(), 0);
             case InvokeInstruction instr -> {
-                if (instr.isInterface()) printConstantPoolRefAndValue(instr.method(), instr.count());
+                if (instr.isInterface() && instr.opcode() != Opcode.INVOKESTATIC) printConstantPoolRefAndValue(instr.method(), instr.count());
                 else printConstantPoolRef(instr.method());
             }
             case LoadInstruction instr ->

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ConstantWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ConstantWriter.java
@@ -80,7 +80,7 @@ public class ConstantWriter extends BasicWriter {
                     println("// " + stringValue(info));
                 }
                 case DynamicConstantPoolEntry info -> {
-                    print("#" + info.bootstrap().bootstrapMethod().index() + ":#" + info.nameAndType().index());
+                    print("#" + info.bootstrap().bsmIndex() + ":#" + info.nameAndType().index());
                     tab();
                     println("// " + stringValue(info));
                 }
@@ -236,7 +236,20 @@ public class ConstantWriter extends BasicWriter {
             case ModuleEntry info -> checkName(info.name().stringValue());
             case NameAndTypeEntry info -> checkName(info.name().stringValue()) + ':' + info.type().stringValue();
             case PackageEntry info -> checkName(info.name().stringValue());
-            case MethodHandleEntry info -> info.asSymbol().kind() + " " + stringValue(info.reference());
+            case MethodHandleEntry info -> {
+                String kind = switch (info.asSymbol().kind()) {
+                    case STATIC, INTERFACE_STATIC -> "REF_invokeStatic";
+                    case VIRTUAL -> "REF_invokeVirtual";
+                    case INTERFACE_VIRTUAL -> "REF_invokeInterface";
+                    case SPECIAL, INTERFACE_SPECIAL -> "REF_invokeSpecial";
+                    case CONSTRUCTOR -> "REF_newInvokeSpecial";
+                    case GETTER -> "REF_getField";
+                    case SETTER -> "REF_putField";
+                    case STATIC_GETTER -> "REF_getStatic";
+                    case STATIC_SETTER -> "REF_putStatic";
+                };
+                yield kind + " " + stringValue(info.reference());
+            }
             case MethodTypeEntry info -> info.descriptor().stringValue();
             case StringEntry info -> stringValue(info.utf8());
             case Utf8Entry info -> {

--- a/test/langtools/tools/javap/InnerClass.java
+++ b/test/langtools/tools/javap/InnerClass.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8032869
+ * @summary javap should render inner classes in a friendly way
+ * @modules jdk.jdeps/com.sun.tools.javap
+ */
+
+import java.io.*;
+import java.util.function.Function;
+import javax.lang.model.element.ElementKind;
+
+public class InnerClass {
+    public static void main(String... args) throws Exception {
+        new InnerClass().run();
+    }
+
+    void run() throws Exception {
+        String testClasses = System.getProperty("test.classes");
+        String out = javap("-v", "-classpath", testClasses, A.class.getName());
+
+        String nl = System.getProperty("line.separator");
+        out = out.replaceAll(nl, "\n");
+
+        if (out.contains("\n\n\n"))
+            error("double blank line found");
+
+        expect(out,
+                "InnerClasses:\n" +
+                        "  public static #17= #7 of #14;           // A=class InnerClass$A of class InnerClass\n" +
+                        "  public #20= #18 of #7;                  // L=class InnerClass$A$L of class InnerClass$A\n" +
+                        "  protected #23= #21 of #7;               // K=class InnerClass$A$K of class InnerClass$A\n" +
+                        "  static #29= #27 of #7;                  // I=class InnerClass$A$I of class InnerClass$A\n" +
+                        "  static #32= #30 of #7;                  // H=class InnerClass$A$H of class InnerClass$A\n" +
+                        "  static final #35= #33 of #7;            // G=class InnerClass$A$G of class InnerClass$A\n" +
+                        "  static #38= #36 of #7;                  // F=class InnerClass$A$F of class InnerClass$A\n" +
+                        "  static final #41= #39 of #7;            // E=class InnerClass$A$E of class InnerClass$A\n" +
+                        "  final #44= #42 of #7;                   // D=class InnerClass$A$D of class InnerClass$A\n" +
+                        "  abstract #47= #45 of #7;                // C=class InnerClass$A$C of class InnerClass$A\n" +
+                        "  #50= #48 of #7;                         // B=class InnerClass$A$B of class InnerClass$A");
+
+        if (errors > 0)
+            throw new Exception(errors + " errors found");
+    }
+
+    String javap(String... args) throws Exception {
+        StringWriter sw = new StringWriter();
+        int rc;
+        try (PrintWriter out = new PrintWriter(sw)) {
+            rc = com.sun.tools.javap.Main.run(args, out);
+        }
+        System.out.println(sw.toString());
+        if (rc < 0)
+            throw new Exception("javap exited, rc=" + rc);
+        return sw.toString();
+    }
+
+    void expect(String text, String expect) {
+        if (!text.contains(expect))
+            error("expected text not found");
+    }
+
+    void error(String msg) {
+        System.out.println("Error: " + msg);
+        errors++;
+    }
+
+    int errors;
+
+    /* Simple test classes to run through javap. */
+    public static class A {
+
+        class B { }
+        abstract class C { }
+        final class D { }
+        static final class E { }
+        static class F { }
+        static final class G { }
+        interface H { }
+        @interface I { }
+        private class J { }
+        protected class K { }
+        public class L { }
+    }
+}

--- a/test/langtools/tools/javap/InvokeDynamic.java
+++ b/test/langtools/tools/javap/InvokeDynamic.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8032869
+ * @summary javap should render dynamic constants in a friendly way
+ * @modules jdk.jdeps/com.sun.tools.javap
+ */
+
+import java.io.*;
+import java.util.function.Function;
+import javax.lang.model.element.ElementKind;
+
+public class InvokeDynamic {
+    public static void main(String... args) throws Exception {
+        new InvokeDynamic().run();
+    }
+
+    void run() throws Exception {
+        String testClasses = System.getProperty("test.classes");
+        String out = javap("-v", "-classpath", testClasses, A.class.getName());
+
+        String nl = System.getProperty("line.separator");
+        out = out.replaceAll(nl, "\n");
+
+        if (out.contains("\n\n\n"))
+            error("double blank line found");
+
+        expect(out,
+                "#26 = MethodHandle       6:#27          // REF_invokeStatic java/lang/invoke/LambdaMetafactory.metafactory:(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;");
+        expect(out,
+                "BootstrapMethods:\n" +
+                        "  0: #26 REF_invokeStatic java/lang/invoke/LambdaMetafactory.metafactory:(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;\n" +
+                        "    Method arguments:\n" +
+                        "      #33 (Ljava/lang/Object;)Ljava/lang/Object;\n" +
+                        "      #35 REF_invokeStatic InvokeDynamic$A.lambda$i$0:(Ljava/lang/String;)Ljava/lang/String;\n" +
+                        "      #38 (Ljava/lang/String;)Ljava/lang/String;");
+
+        if (errors > 0)
+            throw new Exception(errors + " errors found");
+    }
+
+    String javap(String... args) throws Exception {
+        StringWriter sw = new StringWriter();
+        int rc;
+        try (PrintWriter out = new PrintWriter(sw)) {
+            rc = com.sun.tools.javap.Main.run(args, out);
+        }
+        System.out.println(sw.toString());
+        if (rc < 0)
+            throw new Exception("javap exited, rc=" + rc);
+        return sw.toString();
+    }
+
+    void expect(String text, String expect) {
+        if (!text.contains(expect))
+            error("expected text not found");
+    }
+
+    void error(String msg) {
+        System.out.println("Error: " + msg);
+        errors++;
+    }
+
+    int errors;
+
+    /* Simple test classes to run through javap. */
+    public static class A {
+        Function<String, String> i() {
+            return value -> value;
+        }
+    }
+}


### PR DESCRIPTION
1. Never print labels but byte code offsets.
2. Do not print the (implicit) abstract flag for inner interfaces or annotations.
3. Do not print the count for static invocations on interfaces.
4. Print the JVMS "REF" value for method handle entries instead of the enum name. (Arguably, the enum name contains more information if a target is an interface, but those constants are not mentioned in the specification, this is why I found them confusing when using javap.)
5. Use the "bsmIndex" for dynamic constant pool entries.
6. Do not print interpreted data when displaying frames. (Even in previous 'javap' versions, the *chop* frame display did not mention the number of reduced slots, but a class file does not contain the types of frames that are chopped, only the amount. Therefore, I think it is more correct to display this amount rather than the interpreted data.)