### PR TITLE
Fix and test CodeBuilder::swap

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/jdk/classfile/CodeBuilder.java
@@ -1294,7 +1294,7 @@ public sealed interface CodeBuilder
     }
 
     default CodeBuilder swap() {
-        return operatorInstruction(Opcode.SWAP);
+        return stackInstruction(Opcode.SWAP);
     }
 
     default CodeBuilder tableswitch(int low, int high, Label defaultTarget, List<SwitchCase> cases) {

--- a/test/jdk/jdk/classfile/SwapTest.java
+++ b/test/jdk/jdk/classfile/SwapTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Testing swap instruction
+ * @run testng SwapTest
+ */
+
+import jdk.classfile.AccessFlags;
+import jdk.classfile.Classfile;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import static java.lang.reflect.AccessFlag.PUBLIC;
+import static java.lang.reflect.AccessFlag.STATIC;
+
+public class SwapTest {
+    @Test
+    public void testTryCatchCatchAll() throws Throwable {
+        MethodType mt = MethodType.methodType(String.class, String.class, String.class);
+        MethodTypeDesc mtd = mt.describeConstable().get();
+
+        byte[] bytes = Classfile.build(ClassDesc.of("C"), cb -> {
+            cb.withMethodBody("m", mtd, AccessFlags.ofMethod(PUBLIC, STATIC).flagsMask(), xb -> {
+                        xb.aload(0); // 0
+                        xb.aload(1); // 1, 0
+                        xb.swap();   // 0, 1
+                        xb.pop();    // 1
+                        xb.areturn();
+                    });
+        });
+
+        MethodHandles.Lookup lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
+        MethodHandle m = lookup.findStatic(lookup.lookupClass(), "m", mt);
+        Assert.assertEquals(m.invoke("A", "B"), "B");
+    }
+}


### PR DESCRIPTION
CodeBuilder::swap calls the wrong method for given SWAP opcode.