### PR TITLE
ClassRemapper implemenation handling more attributes

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/impl/ConcreteEntry.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/ConcreteEntry.java
@@ -840,7 +840,7 @@ public abstract sealed class ConcreteEntry {
         public DirectMethodHandleDesc asSymbol() {
             return MethodHandleDesc.of(
                     DirectMethodHandleDesc.Kind.valueOf(kind(), reference().isInterface()),
-                    ClassDesc.of(Util.toClassString(((jdk.classfile.constantpool.MemberRefEntry) reference()).owner().asInternalName())),
+                    ((jdk.classfile.constantpool.MemberRefEntry) reference()).owner().asSymbol(),
                     ((jdk.classfile.constantpool.MemberRefEntry) reference()).nameAndType().name().stringValue(),
                     ((jdk.classfile.constantpool.MemberRefEntry) reference()).nameAndType().type().stringValue());
         }


### PR DESCRIPTION
ClassRemapper implemenation handling RecordAttribute, InnerClassesAttribute, EnclosingMethodAttribute, Annotations, TypeAnnotations, ParameterAnnotations and LoadableConstants