### PR TITLE
Sketch of with(NMA, additions) api additions

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/attribute/NestMembersAttribute.java
+++ b/src/java.base/share/classes/jdk/classfile/attribute/NestMembersAttribute.java
@@ -81,4 +81,42 @@ public sealed interface NestMembersAttribute extends Attribute<NestMembersAttrib
         // List view, since ref to nestMembers is temporary
         return ofSymbols(Arrays.asList(nestMembers));
     }
+
+    /**
+     * {@return a {@code NestMembers} attribute}
+     * @param base the provider of the base set of nest member classes
+     * @param additions the additions to nest members
+     */
+    static NestMembersAttribute with(NestMembersAttribute base, List<ClassEntry> additions) {
+        return new UnboundAttribute.UnboundNestMembersAttribute(base.nestMembers().addAll(additions));
+    }
+
+    /**
+     * {@return a {@code NestMembers} attribute}
+     * @param base the provider of the base set of nest member classes
+     * @param additions the additions to nest members
+     */
+    static NestMembersAttribute with(NestMembersAttribute base, ClassEntry... additions) {
+        return with(base, List.of(additions));
+    }
+
+    /**
+     * {@return a {@code NestMembers} attribute}
+     * @param nma the provider of the base set of nest member classes
+     * @param additions the additions to nest members
+     *
+     */
+    static NestMembersAttribute withSymbols(NestMembersAttribute nma, List<ClassDesc> additions) {
+        return of(Util.entryList(nma.nestMembers(), additions));
+    }
+
+    /**
+     * {@return a {@code NestMembers} attribute}
+     * @param base the provider of the base set of nest member classes
+     * @param additions the additions to nest members
+     *
+     */
+    static NestMembersAttribute withSymbols(NestMembersAttribute base, ClassDesc... additions) {
+        return withSymbols(nma, Arrays.asList(additions));
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/attribute/NestMembersAttribute.java
+++ b/src/java.base/share/classes/jdk/classfile/attribute/NestMembersAttribute.java
@@ -25,6 +25,7 @@
 package jdk.classfile.attribute;
 
 import java.lang.constant.ClassDesc;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -88,7 +89,9 @@ public sealed interface NestMembersAttribute extends Attribute<NestMembersAttrib
      * @param additions the additions to nest members
      */
     static NestMembersAttribute with(NestMembersAttribute base, List<ClassEntry> additions) {
-        return new UnboundAttribute.UnboundNestMembersAttribute(base.nestMembers().addAll(additions));
+        ArrayList<ClassEntry> members = new ArrayList<>(base.nestMembers());
+        members.addAll(additions);
+        return new UnboundAttribute.UnboundNestMembersAttribute(members);
     }
 
     /**
@@ -102,12 +105,12 @@ public sealed interface NestMembersAttribute extends Attribute<NestMembersAttrib
 
     /**
      * {@return a {@code NestMembers} attribute}
-     * @param nma the provider of the base set of nest member classes
+     * @param base the provider of the base set of nest member classes
      * @param additions the additions to nest members
      *
      */
-    static NestMembersAttribute withSymbols(NestMembersAttribute nma, List<ClassDesc> additions) {
-        return of(Util.entryList(nma.nestMembers(), additions));
+    static NestMembersAttribute withSymbols(NestMembersAttribute base, List<ClassDesc> additions) {
+        return with(base, Util.entryList(additions));
     }
 
     /**
@@ -117,6 +120,6 @@ public sealed interface NestMembersAttribute extends Attribute<NestMembersAttrib
      *
      */
     static NestMembersAttribute withSymbols(NestMembersAttribute base, ClassDesc... additions) {
-        return withSymbols(nma, Arrays.asList(additions));
+        return withSymbols(base, Arrays.asList(additions));
     }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/Util.java
@@ -26,6 +26,7 @@ package jdk.classfile.impl;
 
 import java.lang.constant.ClassDesc;
 import java.util.AbstractList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Iterator;
@@ -193,6 +194,17 @@ public class Util {
         ClassEntry[] result = new ClassEntry[list.size()]; // null check
         for (int i = 0; i < result.length; i++) {
             result[i] = TemporaryConstantPool.INSTANCE.classEntry(TemporaryConstantPool.INSTANCE.utf8Entry(toInternalName(list.get(i))));
+        }
+        return List.of(result);
+    }
+
+    public static List<ClassEntry> entryList(List<? extends ClassEntry> firstList, List<? extends ClassDesc> secondList) {
+        int firstSize = firstList.size(); // implicit null check
+        int secondSize = secondList.size(); // implicit null check
+        ClassEntry[] result = Arrays.copyOf(original, firstSize + secondSize, ClassEntry[].class);
+
+        for (int i = 0; i < secondSize; i++) {
+            result[firstSize + i] = TemporaryConstantPool.INSTANCE.classEntry(TemporaryConstantPool.INSTANCE.utf8Entry(toInternalName(list.get(i))));
         }
         return List.of(result);
     }

--- a/src/java.base/share/classes/jdk/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/Util.java
@@ -198,17 +198,6 @@ public class Util {
         return List.of(result);
     }
 
-    public static List<ClassEntry> entryList(List<? extends ClassEntry> firstList, List<? extends ClassDesc> secondList) {
-        int firstSize = firstList.size(); // implicit null check
-        int secondSize = secondList.size(); // implicit null check
-        ClassEntry[] result = Arrays.copyOf(original, firstSize + secondSize, ClassEntry[].class);
-
-        for (int i = 0; i < secondSize; i++) {
-            result[firstSize + i] = TemporaryConstantPool.INSTANCE.classEntry(TemporaryConstantPool.INSTANCE.utf8Entry(toInternalName(list.get(i))));
-        }
-        return List.of(result);
-    }
-
     public static void checkKind(Opcode op, CodeElement.Kind k) {
         if (op.kind() != k)
             throw new IllegalArgumentException(


### PR DESCRIPTION
Here's a potential API sketch for the api additions I mentioned in [0].

The API adds a helper method that makes appending values to an existing Attribute a little easier.  I've followed the convention for adding both `::with` methods for processing `ClassEntry`s and `::withSymbols` for dealing with `ClassDesc`s.

I've found these helpful in simplifying my use cases of adding new entries to an attribute where the ordering isn't significant.  While I've only written them for the `NestMembersAttribute` in this PR, I can see the same approach being useful in a number of other attributes.

A quick review of the existing attributes suggest the following list would also benefit from similar additions:

- ExceptionsAttribute
- InnerClassesAttribute
- LineNumberTableAttribute
- LocalVariableTableAttribute
- LocalVariableTypeTableAttribute
- MethodParametersAttribute
- NestMembersAttribute
- PermittedSubclassesAttribute
- RecordAttribute
- RuntimeInvisibleAnnotationsAttribute
- RuntimeInvisibleParameterAnnotationsAttribute
- RuntimeInvisibleTypeAnnotationsAttribute
- RuntimeVisibleAnnotationsAttribute
- RuntimeVisibleParameterAnnotationsAttribute
- RuntimeVisibleTypeAnnotationsAttribute

If we agree on continuing with this approach, I'll update those attributes with similar methods.

[0] https://mail.openjdk.org/pipermail/classfile-api-dev/2022-August/000107.html