### PR TITLE
Add List combining methods to ClassEntry

### DIFF
--- a/src/java.base/share/classes/jdk/classfile/constantpool/ClassEntry.java
+++ b/src/java.base/share/classes/jdk/classfile/constantpool/ClassEntry.java
@@ -108,4 +108,20 @@ sealed public interface ClassEntry
         }
         return List.copyOf(members);
     }
+
+    /**
+     * Remove duplicate ClassEntry elements from the List.
+     *
+     * @param original The list to deduplicate
+     * @return a List without any duplicate ClassEntry
+     */
+    static List<ClassEntry> deduplicate(List<ClassEntry> original) {
+        ArrayList<ClassEntry> newList = new ArrayList<>(original.size());
+        for (ClassEntry e : original) {
+            if (!newList.contains(e)) {
+                newList.add(e);
+            }
+        }
+        return List.copyOf(newList);
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/constantpool/ClassEntry.java
+++ b/src/java.base/share/classes/jdk/classfile/constantpool/ClassEntry.java
@@ -25,8 +25,14 @@
 package jdk.classfile.constantpool;
 
 import java.lang.constant.ClassDesc;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import jdk.classfile.impl.ConcreteEntry;
+import jdk.classfile.impl.TemporaryConstantPool;
+import jdk.classfile.impl.Util;
+
 
 /**
  * Models a {@code CONSTANT_Class_info} constant in the constant pool of a
@@ -50,4 +56,61 @@ sealed public interface ClassEntry
      * {@return the class name, as a symbolic descriptor}
      */
     ClassDesc asSymbol();
+
+    /**
+     * Return a List composed by appending the additions to the base list.
+     * @param base The base elements for the list
+     * @param additions The ClassEntrys to add to the list, must not include null
+     * @return the combined List
+     */
+    static List<ClassEntry> adding(List<ClassEntry> base, List<ClassEntry> additions) {
+        ArrayList<ClassEntry> members = new ArrayList<>(base);
+        // Can't use Collections::addAll as it isn't null-hostile
+        for (ClassEntry e : additions) {
+            Objects.requireNonNull(e);
+            members.add(e);
+        }
+        return members;
+    }
+
+    /**
+     * Return a List composed by appending the additions to the base list.
+     * @param base The base elements for the list
+     * @param additions The ClassEntrys to add to the list, must not include null
+     * @return the combined List
+     */
+    static List<ClassEntry> adding(List<ClassEntry> base, ClassEntry... additions) {
+        ArrayList<ClassEntry> members = new ArrayList<>(base);
+        for (ClassEntry e : additions) {
+            Objects.requireNonNull(e);
+            members.add(e);
+        }
+        return members;
+    }
+
+    /**
+     * Return a List composed by appending the additions to the base list.
+     * @param base The base elements for the list
+     * @param additions The ClassDescs to add to the list, must not include null
+     * @return the combined List
+     */
+    static List<ClassEntry> addingSymbols(List<ClassEntry> base, List<ClassDesc> additions) {
+        ArrayList<ClassEntry> members = new ArrayList<>(base);
+        members.addAll(Util.entryList(additions));
+        return members;
+    }
+
+      /**
+     * Return a List composed by appending the additions to the base list.
+     * @param base The base elements for the list
+     * @param additions The ClassDescs to add to the list, must not include null
+     * @return the combined List
+     */
+    static List<ClassEntry> addingSymbols(List<ClassEntry> base, ClassDesc...additions) {
+        ArrayList<ClassEntry> members = new ArrayList<>(base);
+        for (ClassDesc e : additions) {
+            members.add(TemporaryConstantPool.INSTANCE.classEntry(TemporaryConstantPool.INSTANCE.utf8Entry(Util.toInternalName(e))));
+        }
+        return members;
+    }
 }

--- a/src/java.base/share/classes/jdk/classfile/constantpool/ClassEntry.java
+++ b/src/java.base/share/classes/jdk/classfile/constantpool/ClassEntry.java
@@ -59,50 +59,45 @@ sealed public interface ClassEntry
 
     /**
      * Return a List composed by appending the additions to the base list.
-     * @param base The base elements for the list
+     * @param base The base elements for the list, must not include null
      * @param additions The ClassEntrys to add to the list, must not include null
      * @return the combined List
      */
     static List<ClassEntry> adding(List<ClassEntry> base, List<ClassEntry> additions) {
         ArrayList<ClassEntry> members = new ArrayList<>(base);
-        // Can't use Collections::addAll as it isn't null-hostile
-        for (ClassEntry e : additions) {
-            Objects.requireNonNull(e);
-            members.add(e);
-        }
-        return members;
+        members.addAll(additions);
+        return List.copyOf(members);
     }
 
     /**
      * Return a List composed by appending the additions to the base list.
-     * @param base The base elements for the list
+     * @param base The base elements for the list, must not include null
      * @param additions The ClassEntrys to add to the list, must not include null
      * @return the combined List
      */
     static List<ClassEntry> adding(List<ClassEntry> base, ClassEntry... additions) {
         ArrayList<ClassEntry> members = new ArrayList<>(base);
         for (ClassEntry e : additions) {
-            Objects.requireNonNull(e);
             members.add(e);
         }
-        return members;
+        return List.copyOf(members);
     }
 
     /**
      * Return a List composed by appending the additions to the base list.
-     * @param base The base elements for the list
+     * @param base The base elements for the list, must not include null
      * @param additions The ClassDescs to add to the list, must not include null
      * @return the combined List
      */
     static List<ClassEntry> addingSymbols(List<ClassEntry> base, List<ClassDesc> additions) {
         ArrayList<ClassEntry> members = new ArrayList<>(base);
         members.addAll(Util.entryList(additions));
-        return members;
+        return List.copyOf(members);
     }
 
       /**
      * Return a List composed by appending the additions to the base list.
-     * @param base The base elements for the list
+     * @param base The base elements for the list, must not include null
      * @param additions The ClassDescs to add to the list, must not include null
      * @return the combined List
      */
@@ -111,6 +106,6 @@ sealed public interface ClassEntry
         for (ClassDesc e : additions) {
             members.add(TemporaryConstantPool.INSTANCE.classEntry(TemporaryConstantPool.INSTANCE.utf8Entry(Util.toInternalName(e))));
         }
-        return members;
+        return List.copyOf(members);
     }
 }

--- a/src/java.base/share/classes/jdk/classfile/impl/ConcreteEntry.java
+++ b/src/java.base/share/classes/jdk/classfile/impl/ConcreteEntry.java
@@ -352,6 +352,17 @@ public abstract sealed class ConcreteEntry {
             return toString().subSequence(start, end);
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (o instanceof ConcreteUtf8Entry u) {
+                return equalsUtf8(u);
+            } else if (o instanceof Utf8Entry u) {
+                return equalsString(u.stringValue());
+            }
+            return false;
+        }
+
         public boolean equalsUtf8(ConcreteUtf8Entry u) {
             if (hashCode() != u.hashCode()
                 || length() != u.length())
@@ -520,6 +531,14 @@ public abstract sealed class ConcreteEntry {
         public String asInternalName() {
             return ref1.stringValue();
         }
+
+        public boolean equals(Object o) {
+            if (o == this) { return true; }
+            if (o instanceof NamedEntry ne) {
+                return tag == ne.tag() && name().equals(ref1());
+            }
+            return false;
+        }
     }
 
     public static final class ConcreteClassEntry extends NamedEntry implements ClassEntry {
@@ -542,6 +561,17 @@ public abstract sealed class ConcreteEntry {
         public ClassDesc asSymbol() {
             return Util.toClassDesc(asInternalName());
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (o instanceof ConcreteClassEntry cce) {
+                return cce.name().equals(this.name());
+            } else if (o instanceof ClassEntry c) {
+                return c.asSymbol().equals(this.asSymbol());
+            }
+            return false;
+        }
     }
 
     public static final class ConcretePackageEntry extends NamedEntry implements PackageEntry {
@@ -559,6 +589,15 @@ public abstract sealed class ConcreteEntry {
         public PackageDesc asSymbol() {
             return PackageDesc.ofInternalName(asInternalName());
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (o instanceof PackageEntry p) {
+                return name().equals(p.name());
+            }
+            return false;
+        }
     }
 
     public static final class ConcreteModuleEntry extends NamedEntry implements ModuleEntry {
@@ -575,6 +614,15 @@ public abstract sealed class ConcreteEntry {
         @Override
         public ModuleDesc asSymbol() {
             return ModuleDesc.of(asInternalName());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (o instanceof ConcreteModuleEntry m) {
+                return name().equals(m.name());
+            }
+            return false;
         }
     }
 
@@ -598,6 +646,15 @@ public abstract sealed class ConcreteEntry {
         @Override
         public NameAndTypeEntry clone(ConstantPoolBuilder cp) {
             return cp.canWriteDirect(constantPool) ? this : cp.natEntry(ref1, ref2);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (o instanceof ConcreteNameAndTypeEntry nat) {
+                return name().equals(nat.name()) && type().equals(nat.type());
+            }
+            return false;
         }
     }
 
@@ -624,6 +681,17 @@ public abstract sealed class ConcreteEntry {
         public String toString() {
             return tag() + " " + owner().asInternalName() + "." + nameAndType().name().stringValue()
                    + "-" + nameAndType().type().stringValue();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof MemberRefEntry m) {
+                return tag == m.tag()
+                && owner().equals(m.owner())
+                && nameAndType().equals(m.nameAndType());
+            }
+            return false;
         }
     }
 
@@ -746,6 +814,17 @@ public abstract sealed class ConcreteEntry {
             return tag() + " " + bootstrap() + "." + nameAndType().name().stringValue()
                    + "-" + nameAndType().type().stringValue();
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof AbstractDynamicConstantPoolEntry d) {
+                return this.tag() == d.tag()
+                && bootstrap().equals(d.bootstrap())
+                && nameAndType.equals(d.nameAndType());
+            }
+            return false;
+        }
     }
 
     public static final class ConcreteInvokeDynamicEntry
@@ -862,6 +941,16 @@ public abstract sealed class ConcreteEntry {
             return tag() + " " + kind() + ":" + ((jdk.classfile.constantpool.MemberRefEntry) reference()).owner().asInternalName() + "." + ((jdk.classfile.constantpool.MemberRefEntry) reference()).nameAndType().name().stringValue()
                    + "-" + ((jdk.classfile.constantpool.MemberRefEntry) reference()).nameAndType().type().stringValue();
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof ConcreteMethodHandleEntry m) {
+                return kind() == m.kind()
+                && reference.equals(m.reference());
+            }
+            return false;
+        }
     }
 
     public static final class ConcreteMethodTypeEntry
@@ -884,6 +973,15 @@ public abstract sealed class ConcreteEntry {
         @Override
         public MethodTypeEntry clone(ConstantPoolBuilder cp) {
             return cp.canWriteDirect(constantPool) ? this : cp.methodTypeEntry(ref1);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (o instanceof ConcreteMethodTypeEntry m) {
+                return descriptor().equals(m.descriptor());
+            }
+            return false;
         }
     }
 
@@ -919,6 +1017,18 @@ public abstract sealed class ConcreteEntry {
         public String toString() {
             return tag() + " \"" + stringValue() + "\"";
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (o instanceof ConcreteStringEntry s) {
+                // check utf8 rather allocating a string
+                return utf8().equals(s.utf8());
+            }
+            return false;
+        }
+
+
     }
 
     static abstract sealed class PrimitiveEntry<T extends ConstantDesc>
@@ -966,6 +1076,15 @@ public abstract sealed class ConcreteEntry {
         public int intValue() {
             return value();
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof ConcreteIntegerEntry e) {
+                return intValue() == e.intValue();
+            }
+            return false;
+        }
     }
 
     public static final class ConcreteFloatEntry extends PrimitiveEntry<Float>
@@ -990,6 +1109,15 @@ public abstract sealed class ConcreteEntry {
         public float floatValue() {
             return value();
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof ConcreteFloatEntry e) {
+                return floatValue() == e.floatValue();
+            }
+            return false;
+        }
     }
 
     public static final class ConcreteLongEntry extends PrimitiveEntry<Long> implements LongEntry {
@@ -1013,6 +1141,15 @@ public abstract sealed class ConcreteEntry {
         public long longValue() {
             return value();
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof ConcreteLongEntry e) {
+                return longValue() == e.longValue();
+            }
+            return false;
+        }
     }
 
     public static final class ConcreteDoubleEntry extends PrimitiveEntry<Double> implements DoubleEntry {
@@ -1035,6 +1172,15 @@ public abstract sealed class ConcreteEntry {
         @Override
         public double doubleValue() {
             return value();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof ConcreteDoubleEntry e) {
+                return doubleValue() == e.doubleValue();
+            }
+            return false;
         }
     }
 

--- a/test/jdk/jdk/classfile/ClassEntryTest.java
+++ b/test/jdk/jdk/classfile/ClassEntryTest.java
@@ -11,6 +11,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.testng.Assert.*;
@@ -116,6 +117,30 @@ public class ClassEntryTest {
         Assert.assertEquals(base, ClassEntry.adding(base, new ClassEntry[0]));
         Assert.assertEquals(base, ClassEntry.addingSymbols(base, List.of()));
         Assert.assertEquals(base, ClassEntry.addingSymbols(base, new ClassDesc[0]));
+    }
+
+    @Test
+    void dedup() {
+        {
+            List<ClassEntry> duplicates = ClassEntry.adding(base, base);
+            List<ClassEntry> dedup = ClassEntry.deduplicate(duplicates);
+            boolean result = listCompare(base, dedup);
+            if (!result) {
+                fail("Different: " + Arrays.toString(base.toArray())+ " : " + Arrays.toString(dedup.toArray()));
+            }
+            Assert.assertTrue(result);
+        }
+        {
+            List<ClassEntry> duplicates = ClassEntry.addingSymbols(List.of(), additionCD);
+            duplicates = ClassEntry.addingSymbols(duplicates, additionCD);
+            List<ClassEntry> dedup = ClassEntry.deduplicate(duplicates);
+            boolean result = listCompare(base, dedup);
+            if (!result) {
+                fail("Different: " + Arrays.toString(base.toArray())+ " : " + Arrays.toString(dedup.toArray()));
+            }
+            Assert.assertTrue(result);
+        }
+
     }
 
 }

--- a/test/jdk/jdk/classfile/ClassEntryTest.java
+++ b/test/jdk/jdk/classfile/ClassEntryTest.java
@@ -1,0 +1,121 @@
+/*
+ * @test
+ * @summary Testing Classfile ClassEntry lists methods.
+ * @run testng ClassEntryTest
+ */
+import jdk.classfile.constantpool.ClassEntry;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class ClassEntryTest {
+
+    static final List<ClassEntry> additionCE = List.copyOf(ClassEntry.addingSymbols(List.of(), new ClassDesc[] {ConstantDescs.CD_void, ConstantDescs.CD_Enum, ConstantDescs.CD_Class}));
+    static final List<ClassDesc> additionCD = List.of(ConstantDescs.CD_void, ConstantDescs.CD_Enum, ConstantDescs.CD_Class);
+    static final List<ClassEntry> base = List.copyOf(additionCE);
+
+    @Test
+    public void testNPECombos() {
+        // NPE on first param
+        try {
+            ClassEntry.adding(null, additionCE);
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        try {
+            ClassEntry.adding(null, additionCE.get(1), additionCE.get(2));
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        try {
+            ClassEntry.addingSymbols(null, additionCD);
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        try {
+            ClassEntry.addingSymbols(null, additionCD.get(1), additionCD.get(2));
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        // NPE on second param
+        try {
+            ClassEntry.adding(base, (List<ClassEntry>)null);
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        try {
+            ClassEntry.adding(base, (ClassEntry[])null);
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        try {
+            ClassEntry.addingSymbols(base, (List<ClassDesc>)null);
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        try {
+            ClassEntry.addingSymbols(base, (ClassDesc[])null);
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+    }
+
+    @Test
+    void combine() {
+        List<ClassEntry> expected = new ArrayList<>(base);
+        expected.addAll(additionCE);
+        expected = List.copyOf(expected);
+        // Ensure inputs are equivalent before using 'expected' as a common result
+        Assert.assertTrue(listCompare(additionCE, ClassEntry.addingSymbols(List.<ClassEntry>of(), additionCD)));
+        Assert.assertTrue(listCompare(expected, ClassEntry.adding(base, additionCE)));
+        Assert.assertTrue(listCompare(expected, ClassEntry.adding(base, additionCE.toArray(new ClassEntry[0]))));
+        Assert.assertTrue(listCompare(expected, ClassEntry.addingSymbols(base, additionCD)));
+        Assert.assertTrue(listCompare(expected, ClassEntry.addingSymbols(base, additionCD.toArray(new ClassDesc[0]))));
+    }
+
+    boolean listCompare(List<ClassEntry> a, List<ClassEntry> b) {
+        if (a.size() != b.size()) return false;
+
+        for (int i = 0; i < a.size(); i++) {
+            ClassEntry ca = a.get(i);
+            ClassEntry cb = b.get(i);
+            if (!ca.asSymbol().equals(cb.asSymbol())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Test
+    void throwOnNullAdditions() {
+        // NPE when adding a null element
+        ArrayList<ClassEntry> withNullElement = new ArrayList<ClassEntry>(additionCE);
+        withNullElement.add(null);
+        try {
+            ClassEntry.adding(base, withNullElement);
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        try {
+            ClassEntry.adding(base, withNullElement.toArray(new ClassEntry[0]));
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        ArrayList<ClassDesc> withNullElementCD = new ArrayList<ClassDesc>(additionCD);
+        withNullElementCD.add(null);
+        try {
+            ClassEntry.addingSymbols(base, withNullElementCD);
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+        try {
+            ClassEntry.addingSymbols(base, withNullElementCD.toArray(new ClassDesc[0]));
+            fail("NPE expected");
+        } catch(NullPointerException e) { }
+    }
+
+    @Test
+    void addEmpty() {
+        Assert.assertEquals(base, ClassEntry.adding(base, List.of()));
+        Assert.assertEquals(base, ClassEntry.adding(base, new ClassEntry[0]));
+        Assert.assertEquals(base, ClassEntry.addingSymbols(base, List.of()));
+        Assert.assertEquals(base, ClassEntry.addingSymbols(base, new ClassDesc[0]));
+    }
+
+}


### PR DESCRIPTION
jdk.classfile.ClassEntry and java.lang.constant.ClassDesc are two ways
of describing similar data. Often when working with Attributes, we need to
create lists that combine ClassEntrys and ClassDescs into a single list

This PR adds support working with such lists by adding 4 static methods
to ClassEntry:
* List<CE> adding(List<CE> base, List<CE> additions)
* List<CE> adding(List<CE> base, CE... additions)
* List<CE> addingSymbols(List<CE> base, List<CD> additions)
* List<CE> addingSymbols(List<CE> base, CD...additions)

This methods convert from CD to CE to create a combined List<CE>.
The methods are null-hostile in the "additions" but do not check for
nulls in the "base" List.

The returned List is mutable so these methods can be common building
blocks for composing with other CE entries.

A test has been added that validates the existing behaviours.