### PR TITLE
Flip `assertEquals` calls in Classfile API tests

### DIFF
--- a/test/jdk/jdk/classfile/AccessFlagsTest.java
+++ b/test/jdk/jdk/classfile/AccessFlagsTest.java
@@ -65,10 +65,10 @@ class AccessFlagsTest {
         var r = new Random(123);
         for (int i = 0; i < 1000; i++) {
             var randomFlags = allFlags.stream().filter(f -> r.nextBoolean()).toArray(AccessFlag[]::new);
-            assertEquals(intFactory.apply(flagsFactory.apply(randomFlags).flagsMask()).flags(), Set.of(randomFlags));
+            assertEquals(Set.of(randomFlags), intFactory.apply(flagsFactory.apply(randomFlags).flagsMask()).flags());
 
             var randomMask = r.nextInt(Short.MAX_VALUE);
-            assertEquals(intFactory.apply(randomMask).flagsMask(), randomMask);
+            assertEquals(randomMask, intFactory.apply(randomMask).flagsMask());
         }
     }
 

--- a/test/jdk/jdk/classfile/AdaptCodeTest.java
+++ b/test/jdk/jdk/classfile/AdaptCodeTest.java
@@ -65,7 +65,7 @@ class AdaptCodeTest {
                     new ByteArrayClassLoader(AdaptCodeTest.class.getClassLoader(), testClassName, newBytes)
                             .getMethod(testClassName, "many")
                             .invoke(null, "Blah");
-            assertEquals(result, THIRTEEN);
+            assertEquals(THIRTEEN, result);
         }
     }
 
@@ -106,7 +106,7 @@ class AdaptCodeTest {
                 new ByteArrayClassLoader(AdaptCodeTest.class.getClassLoader(), testClassName, newBytes)
                         .getMethod(testClassName, "many")
                         .invoke(null, "Blah");
-        assertEquals(result, SEVEN);
+        assertEquals(SEVEN, result);
     }
 
     @Test
@@ -118,7 +118,7 @@ class AdaptCodeTest {
                 new ByteArrayClassLoader(AdaptCodeTest.class.getClassLoader(), testClassName, newBytes)
                         .getMethod(testClassName, "many")
                         .invoke(null, "Blah");
-        assertEquals(result, THIRTEEN);
+        assertEquals(THIRTEEN, result);
     }
 
     public static class TestClass {

--- a/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
+++ b/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
@@ -176,10 +176,10 @@ class AdvancedTransformationsTest {
                                 Classfile.buildModule(
                                         ModuleAttribute.of(ModuleDesc.of("MyModule"), mab ->
                                                 mab.uses(foo).provides(foo, foo)))))).findAttribute(Attributes.MODULE).get();
-        assertEquals(ma.uses().get(0).asSymbol(), bar);
+        assertEquals(bar, ma.uses().get(0).asSymbol());
         var provides = ma.provides().get(0);
-        assertEquals(provides.provides().asSymbol(), bar);
-        assertEquals(provides.providesWith().get(0).asSymbol(), bar);
+        assertEquals(bar, provides.provides().asSymbol());
+        assertEquals(bar, provides.providesWith().get(0).asSymbol());
     }
 
     @Test
@@ -239,7 +239,7 @@ class AdvancedTransformationsTest {
         var instrumentedBytes = instrument(target, instrumentor, mm -> mm.methodName().stringValue().equals("instrumentedMethod"));
         assertEmpty(Classfile.parse(instrumentedBytes).verify(null)); //System.out::print));
         var targetClass = new ByteArrayClassLoader(AdvancedTransformationsTest.class.getClassLoader(), "AdvancedTransformationsTest$TargetClass", instrumentedBytes).loadClass("AdvancedTransformationsTest$TargetClass");
-        assertEquals(targetClass.getDeclaredMethod("instrumentedMethod", Boolean.class).invoke(targetClass.getDeclaredConstructor().newInstance(), false), 34);
+        assertEquals(34, targetClass.getDeclaredMethod("instrumentedMethod", Boolean.class).invoke(targetClass.getDeclaredConstructor().newInstance(), false));
     }
 
     public static class InstrumentorClass {
@@ -252,16 +252,16 @@ class AdvancedTransformationsTest {
         //matching methods are instrumenting frames
         public int instrumentedMethod(Boolean instrumented) {
 //            System.out.println("instrumentor start");
-            assertEquals(privateField, "hi");
+            assertEquals("hi", privateField);
             int local = 42;
             instrumented = true;
             //matching method call is inlined
             instrumentedMethod(instrumented);
             instrumentedMethod(instrumented);
-            assertEquals(local, 42);
-            assertEquals(privateField, "hello");
-            assertEquals(instrumentorField, 0);
-            assertEquals(insHelper(), 77);
+            assertEquals(42, local);
+            assertEquals("hello", privateField);
+            assertEquals(0, instrumentorField);
+            assertEquals(77, insHelper());
 //            System.out.println("instrumentor end");
             return 34;
         }

--- a/test/jdk/jdk/classfile/AnnotationModelTest.java
+++ b/test/jdk/jdk/classfile/AnnotationModelTest.java
@@ -58,6 +58,6 @@ class AnnotationModelTest {
         var model = Classfile.parse(fileBytes);
         var annotations = model.findAttribute(Attributes.RUNTIME_VISIBLE_ANNOTATIONS).get().annotations();
 
-        assertEquals(annotations.size(), 3);
+        assertEquals(3, annotations.size());
     }
 }

--- a/test/jdk/jdk/classfile/AnnotationTest.java
+++ b/test/jdk/jdk/classfile/AnnotationTest.java
@@ -83,16 +83,16 @@ class AnnotationTest {
     }
 
     private static boolean assertAnno(Annotation a, String annoClassDescriptor, boolean deep) {
-        assertEquals(a.className().stringValue(), annoClassDescriptor);
-        assertEquals(a.elements().size(), deep ? 13 : 12);
+        assertEquals(annoClassDescriptor, a.className().stringValue());
+        assertEquals(deep ? 13 : 12, a.elements().size());
         Set<String> names = new HashSet<>();
         for (AnnotationElement evp : a.elements()) {
             names.add(evp.name().stringValue());
             switch (evp.name().stringValue()) {
                 case "i", "j", "s", "b", "f", "d", "z", "c", "st":
                     assertTrue (evp.value() instanceof AnnotationValue.OfConstant c);
-                    assertEquals(((AnnotationValue.OfConstant) evp.value()).constantValue(),
-                                 constants.get(evp.name().stringValue()));
+                    assertEquals(constants.get(evp.name().stringValue()),
+                                 ((AnnotationValue.OfConstant) evp.value()).constantValue());
                     break;
                 case "cl":
                     assertTrue (evp.value() instanceof AnnotationValue.OfClass c
@@ -109,15 +109,15 @@ class AnnotationTest {
                 case "arr":
                     assertTrue (evp.value() instanceof AnnotationValue.OfArray);
                     List<AnnotationValue> values = ((AnnotationValue.OfArray) evp.value()).values();
-                    assertEquals(values.stream().map(v -> ((AnnotationValue.OfConstant) v).constant().constantValue()).collect(toSet()),
-                                 Set.of(1, 1.0f, "1"));
+                    assertEquals(Set.of(1, 1.0f, "1"),
+                                 values.stream().map(v -> ((AnnotationValue.OfConstant) v).constant().constantValue()).collect(toSet()));
                     break;
                 default:
                     fail("Unexpected annotation element: " + evp.name().stringValue());
 
             }
         }
-        assertEquals(names.size(), a.elements().size());
+        assertEquals(a.elements().size(), names.size());
         return true;
     }
 
@@ -155,9 +155,9 @@ class AnnotationTest {
                                      .map(ce -> (RuntimeVisibleAnnotationsAttribute) ce)
                                      .flatMap(am -> am.annotations().stream())
                                      .collect(toList());
-        assertEquals(annos.size(), 1);
-        assertEquals(mannos.size(), 1);
-        assertEquals(fannos.size(), 1);
+        assertEquals(1, annos.size());
+        assertEquals(1, mannos.size());
+        assertEquals(1, fannos.size());
         assertAnno(annos.get(0), "LAnno;", true);
         assertAnno(mannos.get(0), "LAnno;", true);
         assertAnno(fannos.get(0), "LAnno;", true);
@@ -200,9 +200,9 @@ class AnnotationTest {
                 .map(ce -> (RuntimeVisibleAnnotationsAttribute) ce)
                 .flatMap(am -> am.annotations().stream())
                 .toList();
-        assertEquals(annos.size(), 1);
-        assertEquals(mannos.size(), 1);
-        assertEquals(fannos.size(), 1);
+        assertEquals(1, annos.size());
+        assertEquals(1, mannos.size());
+        assertEquals(1, fannos.size());
         assertAnno(annos.get(0), "LAnno;", true);
         assertAnno(mannos.get(0), "LAnno;", true);
         assertAnno(fannos.get(0), "LAnno;", true);

--- a/test/jdk/jdk/classfile/ArrayTest.java
+++ b/test/jdk/jdk/classfile/ArrayTest.java
@@ -67,37 +67,35 @@ class ArrayTest {
                         switch (arrayCreateCount++) {
                             case 1: {
                                 NewMultiArrayInstruction nai = (NewMultiArrayInstruction) im;
-                                assertEquals(nai.opcode(), Opcode.MULTIANEWARRAY);
-                                assertEquals(nai.arrayType().asInternalName(), "[[[I");
-                                assertEquals(nai.dimensions(), 3);
+                                assertEquals(Opcode.MULTIANEWARRAY, nai.opcode());
+                                assertEquals("[[[I", nai.arrayType().asInternalName());
+                                assertEquals(3, nai.dimensions());
                                 break;
                             }
                             case 2: {
                                 NewMultiArrayInstruction nai = (NewMultiArrayInstruction) im;
-                                assertEquals(nai.opcode(), Opcode.MULTIANEWARRAY);
-                                assertEquals(nai.arrayType().asInternalName(),
-                                             "[[[Ljava/lang/String;");
-                                assertEquals(nai.dimensions(), 2);
+                                assertEquals(Opcode.MULTIANEWARRAY, nai.opcode());
+                                assertEquals("[[[Ljava/lang/String;", nai.arrayType().asInternalName());
+                                assertEquals(2, nai.dimensions());
                                 break;
                             }
                             case 3: {
                                 NewReferenceArrayInstruction nai = (NewReferenceArrayInstruction) im;
-                                assertEquals(nai.opcode(), Opcode.ANEWARRAY);
-                                assertEquals(nai.componentType().asInternalName(),
-                                             "java/lang/String");
+                                assertEquals(Opcode.ANEWARRAY, nai.opcode());
+                                assertEquals("java/lang/String", nai.componentType().asInternalName());
                                 break;
                             }
                             case 4: {
                                 NewPrimitiveArrayInstruction nai = (NewPrimitiveArrayInstruction) im;
-                                assertEquals(nai.opcode(), Opcode.NEWARRAY);
-                                assertEquals(nai.typeKind(), TypeKind.DoubleType);
+                                assertEquals(Opcode.NEWARRAY, nai.opcode());
+                                assertEquals(TypeKind.DoubleType, nai.typeKind());
                                 break;
                             }
                         }
                     }
                 }
                 if (arrayCreateCount > 1) {
-                    assertEquals(arrayCreateCount, 5);
+                    assertEquals(5, arrayCreateCount);
                 }
             });
         }

--- a/test/jdk/jdk/classfile/BSMTest.java
+++ b/test/jdk/jdk/classfile/BSMTest.java
@@ -96,7 +96,7 @@ public class BSMTest {
                 new ByteArrayClassLoader(BSMTest.class.getClassLoader(), testClassName, newBytes)
                         .getMethod(testClassName, "many")
                         .invoke(null, new Object[0]);
-        assertEquals(result, TWENTY);
+        assertEquals(TWENTY, result);
     }
 
     public static String bootstrap(MethodHandles.Lookup lookup, String name, Class<?> clz, Object arg1, Object arg2) {

--- a/test/jdk/jdk/classfile/BuilderBlockTest.java
+++ b/test/jdk/jdk/classfile/BuilderBlockTest.java
@@ -67,13 +67,13 @@ class BuilderBlockTest {
                               startEnd[0] = xb.startLabel();
                               startEnd[1] = xb.endLabel();
                               xb.returnInstruction(TypeKind.VoidType);
-                              assertEquals(((LabelImpl) startEnd[0]).getContextInfo(), 0);
-                              assertEquals(((LabelImpl) startEnd[1]).getContextInfo(), -1);
+                              assertEquals(0, ((LabelImpl) startEnd[0]).getContextInfo());
+                              assertEquals(-1, ((LabelImpl) startEnd[1]).getContextInfo());
                           }));
         });
 
-        assertEquals(((LabelImpl) startEnd[0]).getContextInfo(), 0);
-        assertEquals(((LabelImpl) startEnd[1]).getContextInfo(), 1);
+        assertEquals(0, ((LabelImpl) startEnd[0]).getContextInfo());
+        assertEquals(1, ((LabelImpl) startEnd[1]).getContextInfo());
     }
 
     @Test
@@ -95,10 +95,10 @@ class BuilderBlockTest {
                           }));
         });
 
-        assertEquals(((LabelImpl) startEnd[0]).getContextInfo(), 0);
-        assertEquals(((LabelImpl) startEnd[1]).getContextInfo(), 3);
-        assertEquals(((LabelImpl) startEnd[2]).getContextInfo(), 1);
-        assertEquals(((LabelImpl) startEnd[3]).getContextInfo(), 2);
+        assertEquals(0, ((LabelImpl) startEnd[0]).getContextInfo());
+        assertEquals(3, ((LabelImpl) startEnd[1]).getContextInfo());
+        assertEquals(1, ((LabelImpl) startEnd[2]).getContextInfo());
+        assertEquals(2, ((LabelImpl) startEnd[3]).getContextInfo());
     }
 
     @Test
@@ -115,8 +115,8 @@ class BuilderBlockTest {
 
         Method fooMethod = new ByteArrayClassLoader(BuilderBlockTest.class.getClassLoader(), "Foo", bytes)
                 .getMethod("Foo", "foo");
-        assertEquals(fooMethod.invoke(null, 3), 1);
-        assertEquals(fooMethod.invoke(null, 0), 2);
+        assertEquals(1, fooMethod.invoke(null, 3));
+        assertEquals(2, fooMethod.invoke(null, 0));
 
     }
 
@@ -133,8 +133,8 @@ class BuilderBlockTest {
 
         Method fooMethod = new ByteArrayClassLoader(BuilderBlockTest.class.getClassLoader(), "Foo", bytes)
                 .getMethod("Foo", "foo");
-        assertEquals(fooMethod.invoke(null, 3), 1);
-        assertEquals(fooMethod.invoke(null, 0), 2);
+        assertEquals(1, fooMethod.invoke(null, 3));
+        assertEquals(2, fooMethod.invoke(null, 0));
 
     }
 
@@ -173,8 +173,8 @@ class BuilderBlockTest {
 
         Method fooMethod = new ByteArrayClassLoader(BuilderBlockTest.class.getClassLoader(), "Foo", bytes)
                 .getMethod("Foo", "foo");
-        assertEquals(fooMethod.invoke(null, 3), 1);
-        assertEquals(fooMethod.invoke(null, 0), 2);
+        assertEquals(1, fooMethod.invoke(null, 3));
+        assertEquals(2, fooMethod.invoke(null, 0));
 
     }
 
@@ -193,8 +193,8 @@ class BuilderBlockTest {
 
         Method fooMethod = new ByteArrayClassLoader(BuilderBlockTest.class.getClassLoader(), "Foo", bytes)
                 .getMethod("Foo", "foo");
-        assertEquals(fooMethod.invoke(null, 3), 1);
-        assertEquals(fooMethod.invoke(null, 0), 2);
+        assertEquals(1, fooMethod.invoke(null, 3));
+        assertEquals(2, fooMethod.invoke(null, 0));
     }
 
     @Test
@@ -216,10 +216,10 @@ class BuilderBlockTest {
 
         Method fooMethod = new ByteArrayClassLoader(BuilderBlockTest.class.getClassLoader(), "Foo", bytes)
                 .getMethod("Foo", "foo");
-        assertEquals(fooMethod.invoke(null, 1, 10), 1);
-        assertEquals(fooMethod.invoke(null, 9, 10), 1);
-        assertEquals(fooMethod.invoke(null, 10, 10), 2);
-        assertEquals(fooMethod.invoke(null, 11, 10), 2);
+        assertEquals(1, fooMethod.invoke(null, 1, 10));
+        assertEquals(1, fooMethod.invoke(null, 9, 10));
+        assertEquals(2, fooMethod.invoke(null, 10, 10));
+        assertEquals(2, fooMethod.invoke(null, 11, 10));
     }
 
     @Test
@@ -252,9 +252,9 @@ class BuilderBlockTest {
                               int slot2 = xb.allocateLocal(TypeKind.LongType);
                               int slot3 = xb.allocateLocal(TypeKind.IntType);
 
-                              assertEquals(slot1, 4);
-                              assertEquals(slot2, 5);
-                              assertEquals(slot3, 7);
+                              assertEquals(4, slot1);
+                              assertEquals(5, slot2);
+                              assertEquals(7, slot3);
                           }));
         });
     }
@@ -269,12 +269,12 @@ class BuilderBlockTest {
                                   int slot2 = bb.allocateLocal(TypeKind.LongType);
                                   int slot3 = bb.allocateLocal(TypeKind.IntType);
 
-                                  assertEquals(slot1, 4);
-                                  assertEquals(slot2, 5);
-                                  assertEquals(slot3, 7);
+                                  assertEquals(4, slot1);
+                                  assertEquals(5, slot2);
+                                  assertEquals(7, slot3);
                               });
                               int slot4 = xb.allocateLocal(TypeKind.IntType);
-                              assertEquals(slot4, 4);
+                              assertEquals(4, slot4);
                           }));
         });
     }
@@ -290,17 +290,17 @@ class BuilderBlockTest {
                                                 int slot2 = bb.allocateLocal(TypeKind.LongType);
                                                 int slot3 = bb.allocateLocal(TypeKind.IntType);
 
-                                                assertEquals(slot1, 4);
-                                                assertEquals(slot2, 5);
-                                                assertEquals(slot3, 7);
+                                                assertEquals(4, slot1);
+                                                assertEquals(5, slot2);
+                                                assertEquals(7, slot3);
                                             },
                                             bb -> {
                                                 int slot1 = bb.allocateLocal(TypeKind.IntType);
 
-                                                assertEquals(slot1, 4);
+                                                assertEquals(4, slot1);
                                             });
                               int slot4 = xb.allocateLocal(TypeKind.IntType);
-                              assertEquals(slot4, 4);
+                              assertEquals(4, slot4);
                               xb.return_();
                           }));
         });

--- a/test/jdk/jdk/classfile/BuilderParamTest.java
+++ b/test/jdk/jdk/classfile/BuilderParamTest.java
@@ -48,19 +48,19 @@ class BuilderParamTest {
         Classfile.build(ClassDesc.of("Foo"), cb -> {
             cb.withMethod("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), 0,
                           mb -> mb.withCode(xb -> {
-                assertEquals(xb.receiverSlot(), 0);
-                assertEquals(xb.parameterSlot(0), 1);
-                assertEquals(xb.parameterSlot(1), 2);
-                assertEquals(xb.parameterSlot(2), 4);
+                assertEquals(0, xb.receiverSlot());
+                assertEquals(1, xb.parameterSlot(0));
+                assertEquals(2, xb.parameterSlot(1));
+                assertEquals(4. xb.parameterSlot(2));
             }));
         });
 
         Classfile.build(ClassDesc.of("Foo"), cb -> {
             cb.withMethod("foo", MethodTypeDesc.ofDescriptor("(IJI)V"), ACC_STATIC,
                           mb -> mb.withCode(xb -> {
-                              assertEquals(xb.parameterSlot(0), 0);
-                              assertEquals(xb.parameterSlot(1), 1);
-                              assertEquals(xb.parameterSlot(2), 3);
+                              assertEquals(0, xb.parameterSlot(0));
+                              assertEquals(1, xb.parameterSlot(1));
+                              assertEquals(3, xb.parameterSlot(2));
                           }));
         });
     }

--- a/test/jdk/jdk/classfile/BuilderTryCatchTest.java
+++ b/test/jdk/jdk/classfile/BuilderTryCatchTest.java
@@ -80,9 +80,9 @@ class BuilderTryCatchTest {
         MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
                 MethodType.methodType(String.class, String[].class));
 
-        assertEquals(main.invoke(new String[]{"BODY"}), "BODY");
-        assertEquals(main.invoke(new String[]{}), "IndexOutOfBoundsException");
-        assertEquals(main.invoke(null), "any");
+        assertEquals("BODY", main.invoke(new String[]{"BODY"}));
+        assertEquals("IndexOutOfBoundsException", main.invoke(new String[]{}));
+        assertEquals("any", main.invoke(null));
     }
 
     @Test
@@ -105,9 +105,9 @@ class BuilderTryCatchTest {
         MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
                 MethodType.methodType(String.class, String[].class));
 
-        assertEquals(main.invoke(new String[]{"BODY"}), "BODY");
-        assertEquals(main.invoke(new String[]{}), "IndexOutOfBoundsException");
-        assertEquals(main.invoke(null), "any");
+        assertEquals("BODY", main.invoke(new String[]{"BODY"}));
+        assertEquals("IndexOutOfBoundsException", main.invoke(new String[]{}));
+        assertEquals("any", main.invoke(null));
     }
 
     @Test
@@ -141,8 +141,8 @@ class BuilderTryCatchTest {
         MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
                 MethodType.methodType(String.class, String[].class));
 
-        assertEquals(main.invoke(new String[]{"BODY"}), "BODY");
-        assertEquals(main.invoke(new String[]{}), "IndexOutOfBoundsException");
+        assertEquals("BODY", main.invoke(new String[]{"BODY"}));
+        assertEquals("IndexOutOfBoundsException", main.invoke(new String[]{}));
         assertThrows(NullPointerException.class,
                 () -> main.invoke(null));
     }
@@ -162,9 +162,9 @@ class BuilderTryCatchTest {
         MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
                 MethodType.methodType(String.class, String[].class));
 
-        assertEquals(main.invoke(new String[]{"BODY"}), "BODY");
-        assertEquals(main.invoke(new String[]{}), "any");
-        assertEquals(main.invoke(null), "any");
+        assertEquals("BODY", main.invoke(new String[]{"BODY"}));
+        assertEquals("any", main.invoke(new String[]{}));
+        assertEquals("any", main.invoke(null));
     }
 
     @Test
@@ -270,9 +270,9 @@ class BuilderTryCatchTest {
         MethodHandle main = lookup.findStatic(lookup.lookupClass(), "main",
                 MethodType.methodType(String.class, String[].class));
 
-        assertEquals(main.invoke(new String[]{"BODY"}), Integer.toString(4));
-        assertEquals(main.invoke(new String[]{}), Double.toString(Math.PI));
-        assertEquals(main.invoke(null), "REF");
+        assertEquals(Integer.toString(4), main.invoke(new String[]{"BODY"}));
+        assertEquals(Double.toString(Math.PI), main.invoke(new String[]{}));
+        assertEquals("REF", main.invoke(null));
     }
 
     static byte[] generateTryCatchMethod(Consumer<CodeBuilder.CatchBuilder> c) {

--- a/test/jdk/jdk/classfile/ClassPrinterTest.java
+++ b/test/jdk/jdk/classfile/ClassPrinterTest.java
@@ -823,19 +823,19 @@ class ClassPrinterTest {
     @Test
     void testWalkTraceAll() throws IOException {
         var node = ClassPrinter.toTree(getClassModel(), ClassPrinter.Verbosity.TRACE_ALL);
-        assertEquals(node.walk().count(), 509);
+        assertEquals(509, node.walk().count());
     }
 
     @Test
     void testWalkCriticalAttributes() throws IOException {
         var node = ClassPrinter.toTree(getClassModel(), ClassPrinter.Verbosity.CRITICAL_ATTRIBUTES);
-        assertEquals(node.walk().count(), 128);
+        assertEquals(128, node.walk().count());
     }
 
     @Test
     void testWalkMembersOnly() throws IOException {
         var node = ClassPrinter.toTree(getClassModel(), ClassPrinter.Verbosity.MEMBERS_ONLY);
-        assertEquals(node.walk().count(), 41);
+        assertEquals(41, node.walk().count());
     }
 
     private static void assertOut(StringBuilder out, String expected) {

--- a/test/jdk/jdk/classfile/ConstantPoolCopyTest.java
+++ b/test/jdk/jdk/classfile/ConstantPoolCopyTest.java
@@ -103,7 +103,7 @@ class ConstantPoolCopyTest {
         ConstantPool cp = c.constantPool();
         ConstantPoolBuilder cp2 = new SplitConstantPool((ClassReader) cp);
 
-        assertEquals(cp2.entryCount(), cp.entryCount(), "Cloned constant pool must be same size");
+        assertEquals(cp.entryCount(), cp2.entryCount(), "Cloned constant pool must be same size");
 
         for (int i = 1; i < cp.entryCount();) {
             PoolEntry cp1i = cp.entryByIndex(i);

--- a/test/jdk/jdk/classfile/LDCTest.java
+++ b/test/jdk/jdk/classfile/LDCTest.java
@@ -84,11 +84,11 @@ class LDCTest {
                           .map(e -> (Instruction)e)
                           .toList();
 
-        assertEquals(opcodes.size(), 4);
-        assertEquals(opcodes.get(0).opcode(), LDC);
-        assertEquals(opcodes.get(1).opcode(), LDC_W);
-        assertEquals(opcodes.get(2).opcode(), LDC);
-        assertEquals(opcodes.get(3).opcode(), RETURN);
+        assertEquals(4, opcodes.size());
+        assertEquals(LDC, opcodes.get(0).opcode());
+        assertEquals(LDC_W, opcodes.get(1).opcode());
+        assertEquals(LDC, opcodes.get(2).opcode());
+        assertEquals(RETURN, opcodes.get(3).opcode());
     }
 
     // TODO test for explicit LDC_W?

--- a/test/jdk/jdk/classfile/LowAdaptTest.java
+++ b/test/jdk/jdk/classfile/LowAdaptTest.java
@@ -98,7 +98,7 @@ class LowAdaptTest {
                 new ByteArrayClassLoader(LowAdaptTest.class.getClassLoader(), test, clazz)
                         .getMethod(test,"doit")
                         .invoke(null, 10);
-        assertEquals(result, 55);
+        assertEquals(55, result);
     }
 
     public static class TestClass {

--- a/test/jdk/jdk/classfile/LowJCovAttributeTest.java
+++ b/test/jdk/jdk/classfile/LowJCovAttributeTest.java
@@ -108,7 +108,7 @@ class LowJCovAttributeTest {
                             }
                             ));
         }
-        assertEquals(mask[0], 7, "Not all JCov attributes seen");
+        assertEquals(7, mask[0], "Not all JCov attributes seen");
     }
 
     private void printf(String format, Object... args) {

--- a/test/jdk/jdk/classfile/LvtTest.java
+++ b/test/jdk/jdk/classfile/LvtTest.java
@@ -177,7 +177,7 @@ class LvtTest {
         var lvt = main.code().get().findAttribute(Attributes.LOCAL_VARIABLE_TABLE).get();
         var lvs = lvt.localVariables();
 
-        assertEquals(lvs.size(), 3);
+        assertEquals(3, lvs.size());
         List<ExpectedLvRecord> expected = List.of(
                 ExpectedLvRecord.of(1, "res", "I", 2, 25),
                 ExpectedLvRecord.of(2, "i", "I", 4, 23),

--- a/test/jdk/jdk/classfile/ModuleBuilderTest.java
+++ b/test/jdk/jdk/classfile/ModuleBuilderTest.java
@@ -104,91 +104,93 @@ class ModuleBuilderTest {
         var cm = Classfile.parse(modBytes);
 
         var attr =cm.findAttribute(Attributes.MODULE).get();
-        assertEquals(attr.moduleName().name().stringValue(), modName.moduleName());
-        assertEquals(attr.moduleFlagsMask(), 0);
-        assertEquals(attr.moduleVersion().get().stringValue(), modVsn);
+        assertEquals(modName.moduleName(), attr.moduleName().name().stringValue());
+        assertEquals(0, attr.moduleFlagsMask());
+        assertEquals(modVsn, attr.moduleVersion().get().stringValue());
     }
 
     @Test
     void testAllAttributes() {
-        assertEquals(moduleModel.attributes().size(), 3);
+        assertEquals(3, moduleModel.attributes().size());
     }
 
     @Test
     void testVerifyRequires() {
-        assertEquals(attr.requires().size(), 2);
+        assertEquals(2, attr.requires().size());
         ModuleRequireInfo r = attr.requires().get(0);
-        assertEquals(r.requires().name().stringValue(), require1.moduleName());
-        assertEquals(r.requiresVersion().get().stringValue(), vsn1);
-        assertEquals(r.requiresFlagsMask(), 77);
+        assertEquals(require1.moduleName(), r.requires().name().stringValue());
+        assertEquals(vsn1, r.requiresVersion().get().stringValue());
+        assertEquals(77, r.requiresFlagsMask());
 
         r = attr.requires().get(1);
-        assertEquals(r.requires().name().stringValue(), require2.moduleName());
-        assertEquals(r.requiresVersion().get().stringValue(), vsn2);
-        assertEquals(r.requiresFlagsMask(), 99);
+        assertEquals(require2.moduleName(), r.requires().name().stringValue());
+        assertEquals(vsn2, r.requiresVersion().get().stringValue());
+        assertEquals(99, r.requiresFlagsMask());
     }
 
     @Test
     void testVerifyExports() {
         List<ModuleExportInfo> exports = attr.exports();
-        assertEquals(exports.size(),5);
+        assertEquals(5, exports.size());
         for (int i = 0; i < 5; i++) {
-            assertEquals(exports.get(i).exportsFlagsMask(), i);
-            assertEquals(exports.get(i).exportedPackage().name().stringValue(), String.valueOf(i));
+            assertEquals(i, exports.get(i).exportsFlagsMask());
+            assertEquals(String.valueOf(i), exports.get(i).exportedPackage().name().stringValue());
         }
-        assertEquals(exports.get(0).exportsTo().size(), 2);
-        for (int i = 0; i < 2; i++)
+        assertEquals(2, exports.get(0).exportsTo().size());
+        for (int i = 0; i < 2; i++) {
             assertEquals(exports.get(0).exportsTo().get(i).name().stringValue(), et1[i].moduleName());
+        }
 
-        assertEquals(exports.get(1).exportsTo().size(), 1);
-        assertEquals(exports.get(1).exportsTo().get(0).name().stringValue(), et2[0].moduleName());
+        assertEquals(1, exports.get(1).exportsTo().size());
+        assertEquals(et2[0].moduleName(), exports.get(1).exportsTo().get(0).name().stringValue());
 
-        assertEquals(exports.get(2).exportsTo().size(), 3);
-        for (int i = 0; i < 3; i++)
+        assertEquals(3, exports.get(2).exportsTo().size());
+        for (int i = 0; i < 3; i++) {
             assertEquals(exports.get(2).exportsTo().get(i).name().stringValue(), et3[i].moduleName());
+        }
 
-        assertEquals(exports.get(3).exportsTo().size(), 0);
-        assertEquals(exports.get(4).exportsTo().size(), 0);
+        assertEquals(0, exports.get(3).exportsTo().size());
+        assertEquals(0, exports.get(4).exportsTo().size());
     }
 
     @Test
     void testVerifyOpens() {
         List<ModuleOpenInfo> opens = attr.opens();
-        assertEquals(opens.size(), 3);
-        assertEquals(opens.get(0).opensTo().size(), 0);
-        assertEquals(opens.get(1).opensTo().size(), 0);
-        assertEquals(opens.get(2).opensTo().size(), 2);
-        assertEquals(opens.get(2).opensFlagsMask(), 2);
-        assertEquals(opens.get(2).opensTo().get(1).name().stringValue(), ot3[1].moduleName());
+        assertEquals(3, opens.size());
+        assertEquals(0, opens.get(0).opensTo().size());
+        assertEquals(0, opens.get(1).opensTo().size());
+        assertEquals(2, opens.get(2).opensTo().size());
+        assertEquals(2, opens.get(2).opensFlagsMask());
+        assertEquals(ot3[1].moduleName(), opens.get(2).opensTo().get(1).name().stringValue());
     }
 
     @Test
     void testVerifyUses() {
         var uses = attr.uses();
-        assertEquals(uses.size(), 2);
-        assertEquals(uses.get(1).asInternalName(), "another/Service");
+        assertEquals(2, uses.size());
+        assertEquals("another/Service", uses.get(1).asInternalName());
     }
 
     @Test
     void testVerifyProvides() {
         var provides = attr.provides();
-        assertEquals(provides.size(), 1);
+        assertEquals(1, provides.size());
         ModuleProvideInfo p = provides.get(0);
-        assertEquals(p.provides().asInternalName(), "some/nice/Feature");
-        assertEquals(p.providesWith().size(), 2);
-        assertEquals(p.providesWith().get(1).asInternalName(), "another/impl");
+        assertEquals("some/nice/Feature", p.provides().asInternalName());
+        assertEquals(2, p.providesWith().size());
+        assertEquals("another/impl", p.providesWith().get(1).asInternalName());
     }
 
     @Test
     void verifyPackages() {
         ModulePackagesAttribute a = moduleModel.findAttribute(Attributes.MODULE_PACKAGES).orElseThrow();
-        assertEquals(a.packages().stream().map(pe -> pe.asSymbol().packageName()).toList(), List.of("0", "1", "2", "3", "4", "o0", "o1", "o2", "foo.bar.baz", "quux"));
+        assertEquals(List.of("0", "1", "2", "3", "4", "o0", "o1", "o2", "foo.bar.baz", "quux"), a.packages().stream().map(pe -> pe.asSymbol().packageName()).toList());
     }
 
     @Test
     void verifyMainclass() {
         ModuleMainClassAttribute a = moduleModel.findAttribute(Attributes.MODULE_MAIN_CLASS).orElseThrow();
-        assertEquals(a.mainClass().asInternalName(), "overwritten/main/Class");
+        assertEquals("overwritten/main/Class", a.mainClass().asInternalName());
     }
 
     @Test

--- a/test/jdk/jdk/classfile/ModuleDescTest.java
+++ b/test/jdk/jdk/classfile/ModuleDescTest.java
@@ -45,6 +45,6 @@ class ModuleDescTest {
     @ValueSource(strings = {"a\\\\b", "a.b/c", "a\\@b\\: c"})
     public void testValidModuleNames(String mdl) {
         assertEquals(ModuleDesc.of(mdl), ModuleDesc.of(mdl));
-        assertEquals(ModuleDesc.of(mdl).moduleName(), mdl);
+        assertEquals(mdl, ModuleDesc.of(mdl).moduleName());
     }
 }

--- a/test/jdk/jdk/classfile/OneToOneTest.java
+++ b/test/jdk/jdk/classfile/OneToOneTest.java
@@ -109,7 +109,7 @@ class OneToOneTest {
 
         ClassModel cm = Classfile.parse(bytes);
         List<MethodModel> ms = cm.methods();
-        assertEquals(ms.size(), 2);
+        assertEquals(2, ms.size());
         boolean found = false;
         for (MethodModel mm : ms) {
             if (mm.methodName().stringValue().equals("main") && mm.code().isPresent()) {
@@ -119,40 +119,40 @@ class OneToOneTest {
                                        .filter(e -> e instanceof Instruction)
                                        .map(e -> (Instruction)e)
                                        .toList();
-                assertEquals(instructions.size(), 17);
+                assertEquals(17, instructions.size());
 
-                assertEquals(instructions.get(0).opcode(), ICONST_1);
+                assertEquals(ICONST_1, instructions.get(0).opcode());
 
                 var i1 = (StoreInstruction) instructions.get(1);
-                assertEquals(i1.opcode(), ISTORE_1);
+                assertEquals(ISTORE_1, i1.opcode());
                 int lv1 = i1.slot();
-                assertEquals(lv1, 1);
+                assertEquals(1, lv1);
 
                 ConstantInstruction i5 = (ConstantInstruction) instructions.get(5);
-                assertEquals(i5.opcode(), BIPUSH);
-                assertEquals(i5.constantValue(), 10);
+                assertEquals(BIPUSH, i5.opcode());
+                assertEquals(10, i5.constantValue());
 
                 BranchInstruction i6 = (BranchInstruction) instructions.get(6);
-                assertEquals(i6.opcode(), IF_ICMPGE);
-                // assertEquals(code.instructionOffset(i6.target()), 14);  //FIXME: CodeModel gives BCI, should give instruction offset
+                assertEquals(IF_ICMPGE, i6.opcode());
+                // assertEquals(14, code.instructionOffset(i6.target()));  //FIXME: CodeModel gives BCI, should give instruction offset
 
                 LoadInstruction i7 = (LoadInstruction) instructions.get(7);
-                assertEquals(i7.opcode(), ILOAD_1);
+                assertEquals(ILOAD_1, i7.opcode());
 
                 OperatorInstruction i9 = (OperatorInstruction) instructions.get(9);
-                assertEquals(i9.opcode(), IMUL);
+                assertEquals(IMUL, i9.opcode());
 
                 FieldInstruction i13 = (FieldInstruction) instructions.get(13);
-                assertEquals(i13.opcode(), GETSTATIC);
-                assertEquals(i13.owner().asInternalName(), "java/lang/System");
-                assertEquals(i13.name().stringValue(), "out");
-                assertEquals(i13.type().stringValue(), "Ljava/io/PrintStream;");
+                assertEquals(GETSTATIC, i13.opcode());
+                assertEquals("java/lang/System", i13.owner().asInternalName());
+                assertEquals("out", i13.name().stringValue());
+                assertEquals("Ljava/io/PrintStream;", i13.type().stringValue());
 
                 InvokeInstruction i15 = (InvokeInstruction) instructions.get(15);
-                assertEquals(i15.opcode(), INVOKEVIRTUAL);
-                assertEquals(i15.owner().asInternalName(), "java/io/PrintStream");
-                assertEquals(i15.name().stringValue(), "println");
-                assertEquals(i15.type().stringValue(), "(I)V");
+                assertEquals(INVOKEVIRTUAL, i15.opcode());
+                assertEquals("java/io/PrintStream", i15.owner().asInternalName());
+                assertEquals("println", i15.name().stringValue());
+                assertEquals("(I)V", i15.type().stringValue());
             }
         }
         assertTrue(found);

--- a/test/jdk/jdk/classfile/ShortJumpsFixTest.java
+++ b/test/jdk/jdk/classfile/ShortJumpsFixTest.java
@@ -250,6 +250,6 @@ class ShortJumpsFixTest {
         for (var e : Classfile.parse(classFile).methods().get(0).code().get())
             if (e instanceof Instruction i && found.peekLast() != i.opcode()) //dedup subsequent (NOPs)
                 found.add(i.opcode());
-        assertEquals(found, List.of(sample.expected));
+        assertEquals(List.of(sample.expected), found);
     }
 }

--- a/test/jdk/jdk/classfile/SignaturesTest.java
+++ b/test/jdk/jdk/classfile/SignaturesTest.java
@@ -131,16 +131,16 @@ class SignaturesTest {
                 var cm = Classfile.parse(path);
                 cm.findAttribute(Attributes.SIGNATURE).ifPresent(csig -> {
                     assertEquals(
-                            ClassSignature.parseFrom(csig.signature().stringValue()).signatureString(),
                             csig.signature().stringValue(),
+                            ClassSignature.parseFrom(csig.signature().stringValue()).signatureString(),
                             cm.thisClass().asInternalName());
                     csc.incrementAndGet();
                 });
                 for (var m : cm.methods()) {
                     m.findAttribute(Attributes.SIGNATURE).ifPresent(msig -> {
                         assertEquals(
-                                MethodSignature.parseFrom(msig.signature().stringValue()).signatureString(),
                                 msig.signature().stringValue(),
+                                MethodSignature.parseFrom(msig.signature().stringValue()).signatureString(),
                                 cm.thisClass().asInternalName() + "::" + m.methodName().stringValue() + m.methodType().stringValue());
                         msc.incrementAndGet();
                     });
@@ -148,8 +148,8 @@ class SignaturesTest {
                 for (var f : cm.fields()) {
                     f.findAttribute(Attributes.SIGNATURE).ifPresent(fsig -> {
                         assertEquals(
-                                Signature.parseFrom(fsig.signature().stringValue()).signatureString(),
                                 fsig.signature().stringValue(),
+                                Signature.parseFrom(fsig.signature().stringValue()).signatureString(),
                                 cm.thisClass().asInternalName() + "." + f.fieldName().stringValue());
                         fsc.incrementAndGet();
                     });
@@ -157,8 +157,8 @@ class SignaturesTest {
                 cm.findAttribute(Attributes.RECORD).ifPresent(reca
                         -> reca.components().forEach(rc -> rc.findAttribute(Attributes.SIGNATURE).ifPresent(rsig -> {
                     assertEquals(
-                            Signature.parseFrom(rsig.signature().stringValue()).signatureString(),
                             rsig.signature().stringValue(),
+                            Signature.parseFrom(rsig.signature().stringValue()).signatureString(),
                             cm.thisClass().asInternalName() + "." + rc.name().stringValue());
                     rsc.incrementAndGet();
                 })));

--- a/test/jdk/jdk/classfile/StackTrackerTest.java
+++ b/test/jdk/jdk/classfile/StackTrackerTest.java
@@ -75,7 +75,7 @@ class StackTrackerTest {
                     }));
                 });
                 assertTrue(stackTracker.maxStackSize().isPresent());
-                assertEquals((int)stackTracker.maxStackSize().get(), 7);
+                assertEquals(7, (int)stackTracker.maxStackSize().get());
             }));
     }
 

--- a/test/jdk/jdk/classfile/SwapTest.java
+++ b/test/jdk/jdk/classfile/SwapTest.java
@@ -59,6 +59,6 @@ class SwapTest {
 
         MethodHandles.Lookup lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
         MethodHandle m = lookup.findStatic(lookup.lookupClass(), "m", mt);
-        assertEquals(m.invoke("A", "B"), "B");
+        assertEquals("B", m.invoke("A", "B"));
     }
 }

--- a/test/jdk/jdk/classfile/TestRecordComponent.java
+++ b/test/jdk/jdk/classfile/TestRecordComponent.java
@@ -67,7 +67,7 @@ class TestRecordComponent {
                 cb.with(ce);
         };
         ClassModel newModel = Classfile.parse(cm.transform(xform));
-        ClassRecord.assertEquals(newModel, cm);
+        ClassRecord.assertEquals(cm, newModel);
     }
 
     @Test
@@ -75,7 +75,7 @@ class TestRecordComponent {
         ClassModel cm = Classfile.parse(Files.readAllBytes(testClassPath));
         ClassTransform xform = (cb, ce) -> cb.with(ce);
         ClassModel newModel = Classfile.parse(cm.transform(xform));
-        ClassRecord.assertEquals(newModel, cm);
+        ClassRecord.assertEquals(cm, newModel);
     }
 
     @Test
@@ -93,11 +93,11 @@ class TestRecordComponent {
         };
         ClassModel newModel = Classfile.parse(cm.transform(xform));
         RecordAttribute ra = newModel.findAttribute(Attributes.RECORD).orElseThrow();
-        assertEquals(ra.components().size(), 2, "Should have two components");
-        assertEquals(ra.components().get(0).name().stringValue(), "fooXYZ");
-        assertEquals(ra.components().get(1).name().stringValue(), "barXYZ");
+        assertEquals(2, ra.components().size(), "Should have two components");
+        assertEquals("fooXYZ", ra.components().get(0).name().stringValue());
+        assertEquals("barXYZ", ra.components().get(1).name().stringValue());
         assertTrue(ra.components().get(0).attributes().isEmpty());
-        assertEquals(newModel.attributes().size(), cm.attributes().size());
+        assertEquals(cm.attributes().size(), newModel.attributes().size());
     }
 
     @Test
@@ -108,8 +108,8 @@ class TestRecordComponent {
             if (ce instanceof RecordAttribute rm) {
                 count.addAndGet(rm.components().size());
             }});
-        assertEquals(count.get(), 2);
-        assertEquals(cm.findAttribute(Attributes.RECORD).orElseThrow().components().size(), 2);
+        assertEquals(2, count.get());
+        assertEquals(2, cm.findAttribute(Attributes.RECORD).orElseThrow().components().size());
 
         count.set(0);
     }

--- a/test/jdk/jdk/classfile/TransformTests.java
+++ b/test/jdk/jdk/classfile/TransformTests.java
@@ -97,9 +97,9 @@ class TransformTests {
         byte[] bytes = Files.readAllBytes(testClassPath);
         ClassModel cm = Classfile.parse(bytes);
 
-        assertEquals(invoke(bytes), "foo");
-        assertEquals(invoke(cm.transform(transformCode(foo2foo))), "foo");
-        assertEquals(invoke(cm.transform(transformCode(foo2bar))), "bar");
+        assertEquals("foo", invoke(bytes));
+        assertEquals("foo", invoke(cm.transform(transformCode(foo2foo))));
+        assertEquals("bar", invoke(cm.transform(transformCode(foo2bar))));
     }
 
     @Test
@@ -108,9 +108,9 @@ class TransformTests {
         byte[] bytes = Files.readAllBytes(testClassPath);
         ClassModel cm = Classfile.parse(bytes);
 
-        assertEquals(invoke(bytes), "foo");
+        assertEquals("foo", invoke(bytes));
         ClassTransform transform = transformCode(foo2bar.andThen(bar2baz));
-        assertEquals(invoke(cm.transform(transform)), "baz");
+        assertEquals("baz", invoke(cm.transform(transform)));
     }
 
     @Test
@@ -119,10 +119,10 @@ class TransformTests {
         byte[] bytes = Files.readAllBytes(testClassPath);
         ClassModel cm = Classfile.parse(bytes);
 
-        assertEquals(invoke(bytes), "foo");
-        assertEquals(invoke(cm.transform(transformCode(foo2bar.andThen(bar2baz).andThen(baz2foo)))), "foo");
-        assertEquals(invoke(cm.transform(transformCode(foo2bar.andThen(bar2baz).andThen(baz2quux)))), "quux");
-        assertEquals(invoke(cm.transform(transformCode(foo2foo.andThen(foo2bar).andThen(bar2baz)))), "baz");
+        assertEquals("foo", invoke(bytes));
+        assertEquals("foo", invoke(cm.transform(transformCode(foo2bar.andThen(bar2baz).andThen(baz2foo)))));
+        assertEquals("quux", invoke(cm.transform(transformCode(foo2bar.andThen(bar2baz).andThen(baz2quux)))));
+        assertEquals("baz", invoke(cm.transform(transformCode(foo2foo.andThen(foo2bar).andThen(bar2baz)))));
     }
 
     public static class TestClass {

--- a/test/jdk/jdk/classfile/Utf8EntryTest.java
+++ b/test/jdk/jdk/classfile/Utf8EntryTest.java
@@ -90,7 +90,7 @@ class Utf8EntryTest {
         assertTrue(utf8Entry.equalsString(s));
 
         // Create string
-        assertEquals(utf8Entry.stringValue(), s);
+        assertEquals(s, utf8Entry.stringValue());
     }
 
     static Stream<UnaryOperator<byte[]>> malformedStringsProvider() {

--- a/test/jdk/jdk/classfile/UtilTest.java
+++ b/test/jdk/jdk/classfile/UtilTest.java
@@ -39,34 +39,34 @@ import static org.junit.jupiter.api.Assertions.*;
 class UtilTest {
     @Test
     void testFindParams() {
-        assertEquals(Util.findParams("(IIII)V").cardinality(), 4);
-        assertEquals(Util.findParams("([I[I[I[I)V").cardinality(), 4);
-        assertEquals(Util.findParams("(IJLFoo;IJ)V").cardinality(), 5);
-        assertEquals(Util.findParams("([[[[I)V").cardinality(), 1);
-        assertEquals(Util.findParams("([[[[LFoo;)V").cardinality(), 1);
-        assertEquals(Util.findParams("([I[LFoo;)V").cardinality(), 2);
-        assertEquals(Util.findParams("()V").cardinality(), 0);
+        assertEquals(4, Util.findParams("(IIII)V").cardinality());
+        assertEquals(4, Util.findParams("([I[I[I[I)V").cardinality());
+        assertEquals(5, Util.findParams("(IJLFoo;IJ)V").cardinality());
+        assertEquals(1, Util.findParams("([[[[I)V").cardinality());
+        assertEquals(1, Util.findParams("([[[[LFoo;)V").cardinality());
+        assertEquals(2, Util.findParams("([I[LFoo;)V").cardinality());
+        assertEquals(0, Util.findParams("()V").cardinality());
     }
 
     @Test
     void testParameterSlots() {
-        assertEquals(Util.parameterSlots("(IIII)V"), 4);
-        assertEquals(Util.parameterSlots("([I[I[I[I)V"), 4);
-        assertEquals(Util.parameterSlots("(IJLFoo;IJ)V"), 7);
-        assertEquals(Util.parameterSlots("([[[[I)V"), 1);
-        assertEquals(Util.parameterSlots("([[[[LFoo;)V"), 1);
-        assertEquals(Util.parameterSlots("([I[LFoo;)V"), 2);
-        assertEquals(Util.parameterSlots("()V"), 0);
-        assertEquals(Util.parameterSlots("(I)V"), 1);
-        assertEquals(Util.parameterSlots("(S)V"), 1);
-        assertEquals(Util.parameterSlots("(C)V"), 1);
-        assertEquals(Util.parameterSlots("(B)V"), 1);
-        assertEquals(Util.parameterSlots("(Z)V"), 1);
-        assertEquals(Util.parameterSlots("(F)V"), 1);
-        assertEquals(Util.parameterSlots("(LFoo;)V"), 1);
-        assertEquals(Util.parameterSlots("(J)V"), 2);
-        assertEquals(Util.parameterSlots("(D)V"), 2);
-        assertEquals(Util.parameterSlots("([J)V"), 1);
-        assertEquals(Util.parameterSlots("([D)V"), 1);
+        assertEquals(4, Util.parameterSlots("(IIII)V"));
+        assertEquals(4, Util.parameterSlots("([I[I[I[I)V"));
+        assertEquals(7, Util.parameterSlots("(IJLFoo;IJ)V"));
+        assertEquals(1, Util.parameterSlots("([[[[I)V"));
+        assertEquals(1, Util.parameterSlots("([[[[LFoo;)V"));
+        assertEquals(2, Util.parameterSlots("([I[LFoo;)V"));
+        assertEquals(0, Util.parameterSlots("()V"));
+        assertEquals(1, Util.parameterSlots("(I)V"));
+        assertEquals(1, Util.parameterSlots("(S)V"));
+        assertEquals(1, Util.parameterSlots("(C)V"));
+        assertEquals(1, Util.parameterSlots("(B)V"));
+        assertEquals(1, Util.parameterSlots("(Z)V"));
+        assertEquals(1, Util.parameterSlots("(F)V"));
+        assertEquals(1, Util.parameterSlots("(LFoo;)V"));
+        assertEquals(2, Util.parameterSlots("(J)V"));
+        assertEquals(2, Util.parameterSlots("(D)V"));
+        assertEquals(1, Util.parameterSlots("([J)V"));
+        assertEquals(1, Util.parameterSlots("([D)V"));
     }
 }


### PR DESCRIPTION
Flip arguments of `assertEquals` calls in Classfile API tests in order to match the `expected, actual, <message>` sequence used by JUnit.

Find some background information here:
- https://stackoverflow.com/questions/26102865/assertequals-what-is-actual-and-what-is-expected
- https://stackoverflow.com/questions/16267660/assert-assertequals-junit-parameters-order